### PR TITLE
Normailize signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,7 @@ dependencies = [
  "rand_chacha",
  "rand_dev",
  "round-based",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2",
@@ -517,7 +524,7 @@ dependencies = [
 [[package]]
 name = "generic-ec"
 version = "0.0.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#39070cded813ef002078faedc3abeb4d6014f8ae"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=d#e264391797f7e2c025e1f633fb996a3aa9178f43"
 dependencies = [
  "generic-array",
  "generic-ec-core",
@@ -534,7 +541,7 @@ dependencies = [
 [[package]]
 name = "generic-ec-core"
 version = "0.1.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#39070cded813ef002078faedc3abeb4d6014f8ae"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=d#e264391797f7e2c025e1f633fb996a3aa9178f43"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -546,7 +553,7 @@ dependencies = [
 [[package]]
 name = "generic-ec-curves"
 version = "0.1.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#39070cded813ef002078faedc3abeb4d6014f8ae"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=d#e264391797f7e2c025e1f633fb996a3aa9178f43"
 dependencies = [
  "elliptic-curve",
  "generic-ec-core",
@@ -561,7 +568,7 @@ dependencies = [
 [[package]]
 name = "generic-ec-zkp"
 version = "0.1.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#39070cded813ef002078faedc3abeb4d6014f8ae"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=d#e264391797f7e2c025e1f633fb996a3aa9178f43"
 dependencies = [
  "digest 0.10.6",
  "generic-array",
@@ -1051,6 +1058,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,9 @@ futures = "0.3"
 
 lazy_static = "1.4"
 
+# external verifiers
+secp256k1 = { version = "0.26", features = ["global-context", "bitcoin-hashes"] }
+
 [dev-dependencies]
 generic-tests = "0.1"
 test-case = "2.2"

--- a/tests/src/external_verifier.rs
+++ b/tests/src/external_verifier.rs
@@ -1,0 +1,56 @@
+use cggmp21::signing::Signature;
+use generic_ec::{Curve, Point};
+
+/// Verifies signature produced by cggmp21 implemenation using external library
+pub trait ExternalVerifier<E: Curve> {
+    fn verify(
+        public_key: &Point<E>,
+        signature: &Signature<E>,
+        message: &[u8],
+    ) -> anyhow::Result<()>;
+}
+
+/// Doesn't do any external verification
+pub struct Noop;
+
+impl<E: Curve> ExternalVerifier<E> for Noop {
+    fn verify(
+        _public_key: &Point<E>,
+        _signature: &Signature<E>,
+        _message: &[u8],
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+pub mod blockchains {
+    use anyhow::Context;
+    use cggmp21::supported_curves::Secp256k1;
+
+    use crate::external_verifier::ExternalVerifier;
+
+    /// Verifies ECDSA signature using the same library as used in Bitcoin
+    pub struct Bitcoin;
+
+    impl ExternalVerifier<Secp256k1> for Bitcoin {
+        fn verify(
+            public_key: &generic_ec::Point<Secp256k1>,
+            signature: &cggmp21::signing::Signature<Secp256k1>,
+            message: &[u8],
+        ) -> anyhow::Result<()> {
+            let public_key = secp256k1::PublicKey::from_slice(&public_key.to_bytes(true))
+                .context("public key is not valid")?;
+            let message =
+                secp256k1::Message::from_hashed_data::<secp256k1::hashes::sha256::Hash>(message);
+
+            let mut signature_bytes = [0u8; 64];
+            signature.write_to_slice(&mut signature_bytes);
+            let signature = secp256k1::ecdsa::Signature::from_compact(&signature_bytes)
+                .context("malformed signature")?;
+
+            signature
+                .verify(&message, &public_key)
+                .context("invalid siganture")
+        }
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,6 +8,8 @@ use generic_ec::Curve;
 use rand::RngCore;
 use serde_json::{Map, Value};
 
+pub mod external_verifier;
+
 lazy_static::lazy_static! {
     pub static ref CACHED_SHARES: PrecomputedKeyShares =
         PrecomputedKeyShares::from_serialized(

--- a/tests/tests/signing.rs
+++ b/tests/tests/signing.rs
@@ -1,7 +1,8 @@
 #[generic_tests::define(attrs(tokio::test, test_case::case))]
 mod generic {
+    use cggmp21_tests::external_verifier::ExternalVerifier;
     use generic_ec::{coords::HasAffineX, hash_to_curve::FromHash, Curve, Point, Scalar};
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaCha20Rng;
     use rand_dev::DevRng;
     use round_based::simulation::Simulation;
@@ -13,10 +14,11 @@ mod generic {
     #[test_case::case(2; "n2")]
     #[test_case::case(3; "n3")]
     #[tokio::test]
-    async fn signing_works<E: Curve>(n: u16)
+    async fn signing_works<E: Curve, V>(n: u16)
     where
         Point<E>: HasAffineX<E>,
         Scalar<E>: FromHash,
+        V: ExternalVerifier<E>,
     {
         let mut rng = DevRng::new();
 
@@ -29,8 +31,9 @@ mod generic {
             ExecutionId::<E, ReasonablySecure>::from_bytes(&signing_execution_id);
         let mut simulation = Simulation::<Msg<E, Sha256>>::new();
 
-        let message_to_sign = b"Dfns rules!";
-        let message_to_sign = Message::new::<Sha256>(message_to_sign);
+        let mut original_message_to_sign = [0u8; 100];
+        rng.fill_bytes(&mut original_message_to_sign);
+        let message_to_sign = Message::new::<Sha256>(&original_message_to_sign);
 
         let mut outputs = vec![];
         for share in &shares {
@@ -55,10 +58,17 @@ mod generic {
             .expect("signature is not valid");
 
         assert!(signatures.iter().all(|s_i| signatures[0] == *s_i));
+
+        V::verify(
+            &shares[0].core.shared_public_key,
+            &signatures[0],
+            &original_message_to_sign,
+        )
+        .expect("external verification failed")
     }
 
-    #[instantiate_tests(<cggmp21::supported_curves::Secp256k1>)]
+    #[instantiate_tests(<cggmp21::supported_curves::Secp256k1, cggmp21_tests::external_verifier::blockchains::Bitcoin>)]
     mod secp256k1 {}
-    #[instantiate_tests(<cggmp21::supported_curves::Secp256r1>)]
+    #[instantiate_tests(<cggmp21::supported_curves::Secp256r1, cggmp21_tests::external_verifier::Noop>)]
     mod secp256r1 {}
 }


### PR DESCRIPTION
Output signatures produced by cggmp are not compatible with bitcoin by default. PR adds signature normalization, and adds tests that verify output signatures using other ecdsa libs