### PR TITLE
Fix warnings when building without features

### DIFF
--- a/cggmp21/src/key_share.rs
+++ b/cggmp21/src/key_share.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
 
-use crate::utils::{lagrange_coefficient, subset};
+use crate::utils::lagrange_coefficient;
 
 /// Key share
 ///
@@ -399,6 +399,8 @@ impl<E: Curve> AsRef<IncompleteKeyShare<E>> for IncompleteKeyShare<E> {
 pub fn reconstruct_secret_key<E: Curve>(
     key_shares: &[impl AnyKeyShare<E>],
 ) -> Result<SecretScalar<E>, ReconstructError> {
+    use crate::utils::subset;
+
     if key_shares.is_empty() {
         return Err(ReconstructErrorReason::NoKeyShares.into());
     }
@@ -559,6 +561,7 @@ enum InvalidKeyShareReason {
     INotPairwiseDistinct,
 }
 
+#[cfg(feature = "spof")]
 #[derive(Debug, Error)]
 #[error("secret key reconstruction error")]
 pub struct ReconstructError(
@@ -567,6 +570,7 @@ pub struct ReconstructError(
     ReconstructErrorReason,
 );
 
+#[cfg(feature = "spof")]
 #[derive(Debug, Error)]
 enum ReconstructErrorReason {
     #[error("no key shares provided")]


### PR DESCRIPTION
When building without spof, we have unused code. Kudelski guys have this problem. You can reproduce it on master by running `cargo build -p cggmp21` (skip tests)