### PR TITLE
Add `KeyInfo`, redesign `Valid<T>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde_with 2.3.3",
  "slip-10",
  "thiserror",
+ "udigest",
 ]
 
 [[package]]

--- a/cggmp21-keygen/src/non_threshold.rs
+++ b/cggmp21-keygen/src/non_threshold.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::progress::Tracer;
 use crate::{
     errors::IoError,
-    key_share::{CoreKeyShare, DirtyCoreKeyShare, Validate},
+    key_share::{CoreKeyShare, DirtyCoreKeyShare, DirtyKeyInfo, Validate},
     security_level::SecurityLevel,
     utils, ExecutionId,
 };
@@ -339,18 +339,20 @@ where
     Ok(DirtyCoreKeyShare {
         curve: Default::default(),
         i,
-        shared_public_key: decommitments
-            .iter_including_me(&my_decommitment)
-            .map(|d| d.X)
-            .sum(),
-        public_shares: decommitments
-            .iter_including_me(&my_decommitment)
-            .map(|d| d.X)
-            .collect(),
+        key_info: DirtyKeyInfo {
+            shared_public_key: decommitments
+                .iter_including_me(&my_decommitment)
+                .map(|d| d.X)
+                .sum(),
+            public_shares: decommitments
+                .iter_including_me(&my_decommitment)
+                .map(|d| d.X)
+                .collect(),
+            vss_setup: None,
+            #[cfg(feature = "hd-wallets")]
+            chain_code,
+        },
         x: x_i,
-        vss_setup: None,
-        #[cfg(feature = "hd-wallets")]
-        chain_code,
     }
     .validate()
     .map_err(|e| Bug::InvalidKeyShare(e.into_error()))?)

--- a/cggmp21-keygen/src/non_threshold.rs
+++ b/cggmp21-keygen/src/non_threshold.rs
@@ -337,9 +337,9 @@ where
     tracer.protocol_ends();
 
     Ok(DirtyCoreKeyShare {
-        curve: Default::default(),
         i,
         key_info: DirtyKeyInfo {
+            curve: Default::default(),
             shared_public_key: decommitments
                 .iter_including_me(&my_decommitment)
                 .map(|d| d.X)

--- a/cggmp21-keygen/src/threshold.rs
+++ b/cggmp21-keygen/src/threshold.rs
@@ -13,7 +13,7 @@ use serde_with::serde_as;
 use crate::progress::Tracer;
 use crate::{
     errors::IoError,
-    key_share::{CoreKeyShare, DirtyCoreKeyShare, Validate, VssSetup},
+    key_share::{CoreKeyShare, DirtyCoreKeyShare, DirtyKeyInfo, Validate, VssSetup},
     security_level::SecurityLevel,
     utils, ExecutionId,
 };
@@ -424,14 +424,16 @@ where
     Ok(DirtyCoreKeyShare {
         curve: Default::default(),
         i,
-        shared_public_key: y,
-        public_shares: ys,
-        vss_setup: Some(VssSetup {
-            min_signers: t,
-            I: key_shares_indexes,
-        }),
-        #[cfg(feature = "hd-wallets")]
-        chain_code,
+        key_info: DirtyKeyInfo {
+            shared_public_key: y,
+            public_shares: ys,
+            vss_setup: Some(VssSetup {
+                min_signers: t,
+                I: key_shares_indexes,
+            }),
+            #[cfg(feature = "hd-wallets")]
+            chain_code,
+        },
         x: sigma,
     }
     .validate()

--- a/cggmp21-keygen/src/threshold.rs
+++ b/cggmp21-keygen/src/threshold.rs
@@ -422,9 +422,9 @@ where
     tracer.protocol_ends();
 
     Ok(DirtyCoreKeyShare {
-        curve: Default::default(),
         i,
         key_info: DirtyKeyInfo {
+            curve: Default::default(),
             shared_public_key: y,
             public_shares: ys,
             vss_setup: Some(VssSetup {

--- a/cggmp21/src/key_refresh/non_threshold.rs
+++ b/cggmp21/src/key_refresh/non_threshold.rs
@@ -20,7 +20,9 @@ use serde::{Deserialize, Serialize};
 use super::{Bug, KeyRefreshError, PregeneratedPrimes, ProtocolAborted};
 use crate::{
     errors::IoError,
-    key_share::{DirtyAuxInfo, DirtyIncompleteKeyShare, KeyShare, PartyAux, Validate},
+    key_share::{
+        DirtyAuxInfo, DirtyIncompleteKeyShare, DirtyKeyInfo, KeyShare, PartyAux, Validate,
+    },
     progress::Tracer,
     security_level::SecurityLevel,
     utils,
@@ -649,6 +651,7 @@ where
             .sum::<Point<E>>()
     });
     let X_stars = old_core_share
+        .key_info
         .public_shares
         .into_iter()
         .zip(X_sums)
@@ -657,7 +660,10 @@ where
 
     tracer.stage("Assemble new core share");
     let new_core_share: IncompleteKeyShare<E> = DirtyIncompleteKeyShare {
-        public_shares: X_stars,
+        key_info: DirtyKeyInfo {
+            public_shares: X_stars,
+            ..old_core_share.key_info
+        },
         x: SecretScalar::new(&mut x_star),
         ..old_core_share
     }

--- a/cggmp21/src/key_share.rs
+++ b/cggmp21/src/key_share.rs
@@ -14,9 +14,9 @@ use crate::security_level::SecurityLevel;
 
 #[doc(inline)]
 pub use cggmp21_keygen::key_share::{
-    CoreKeyShare as IncompleteKeyShare, DirtyCoreKeyShare as DirtyIncompleteKeyShare, HdError,
-    InvalidCoreShare as InvalidIncompleteKeyShare, Valid, Validate, ValidateError,
-    ValidateFromParts, VssSetup,
+    CoreKeyShare as IncompleteKeyShare, DirtyCoreKeyShare as DirtyIncompleteKeyShare, DirtyKeyInfo,
+    HdError, InvalidCoreShare as InvalidIncompleteKeyShare, KeyInfo, Valid, Validate,
+    ValidateError, ValidateFromParts, VssSetup,
 };
 
 /// Key share

--- a/cggmp21/src/key_share.rs
+++ b/cggmp21/src/key_share.rs
@@ -286,6 +286,11 @@ impl<E: Curve, L: SecurityLevel> AsRef<DirtyIncompleteKeyShare<E>> for DirtyKeyS
         &self.core
     }
 }
+impl<E: Curve, L: SecurityLevel> AsRef<DirtyAuxInfo<L>> for DirtyKeyShare<E, L> {
+    fn as_ref(&self) -> &DirtyAuxInfo<L> {
+        &self.aux
+    }
+}
 
 impl<E: Curve, L: SecurityLevel> ops::Deref for DirtyKeyShare<E, L> {
     type Target = DirtyIncompleteKeyShare<E>;

--- a/cggmp21/src/trusted_dealer.rs
+++ b/cggmp21/src/trusted_dealer.rs
@@ -209,9 +209,9 @@ impl<E: Curve, L: SecurityLevel> TrustedDealerBuilder<E, L> {
             .zip(secret_shares)
             .map(|(i, x_i)| {
                 DirtyIncompleteKeyShare::<E> {
-                    curve: Default::default(),
                     i,
                     key_info: DirtyKeyInfo {
+                        curve: Default::default(),
                         shared_public_key,
                         public_shares: public_shares.clone(),
                         vss_setup: vss_setup.clone(),

--- a/cggmp21/src/trusted_dealer.rs
+++ b/cggmp21/src/trusted_dealer.rs
@@ -35,8 +35,8 @@ use thiserror::Error;
 
 use crate::{
     key_share::{
-        AuxInfo, DirtyAuxInfo, DirtyIncompleteKeyShare, IncompleteKeyShare, InvalidKeyShare,
-        KeyShare, PartyAux, Validate, VssSetup,
+        AuxInfo, DirtyAuxInfo, DirtyIncompleteKeyShare, DirtyKeyInfo, IncompleteKeyShare,
+        InvalidKeyShare, KeyShare, PartyAux, Validate, VssSetup,
     },
     security_level::SecurityLevel,
     utils,
@@ -211,12 +211,14 @@ impl<E: Curve, L: SecurityLevel> TrustedDealerBuilder<E, L> {
                 DirtyIncompleteKeyShare::<E> {
                     curve: Default::default(),
                     i,
-                    shared_public_key,
-                    public_shares: public_shares.clone(),
+                    key_info: DirtyKeyInfo {
+                        shared_public_key,
+                        public_shares: public_shares.clone(),
+                        vss_setup: vss_setup.clone(),
+                        #[cfg(feature = "hd-wallets")]
+                        chain_code,
+                    },
                     x: x_i,
-                    vss_setup: vss_setup.clone(),
-                    #[cfg(feature = "hd-wallets")]
-                    chain_code,
                 }
                 .validate()
                 .map_err(|err| Reason::InvalidKeyShare(err.into_error().into()))

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -15,6 +15,7 @@ generic-ec = "0.1.3"
 generic-ec-zkp = "0.1"
 
 slip-10 = { version = "0.1", optional = true, features = ["std"] }
+udigest = { version = "0.1", default-features = false, features = ["derive"], optional = true }
 
 serde = { version = "1", features = ["derive"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["serde"], optional = true }
@@ -25,3 +26,4 @@ thiserror = "1"
 [features]
 serde = ["dep:serde", "serde_with", "hex"]
 hd-wallets = ["slip-10"]
+udigest = ["dep:udigest"]

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -282,30 +282,6 @@ fn validate_non_vss_key_info<E: Curve>(
     Ok(())
 }
 
-impl<E: Curve> DirtyCoreKeyShare<E> {
-    /// Returns share index of j-th signer
-    ///
-    /// * For additive shares, share id is `j+1`
-    /// * For VSS-shares, share id is scalar $I_j$ such that $x_j = F(I_j)$ where
-    ///   $F(x)$ is polynomial co-shared by the signers
-    ///
-    /// Note: if you have no idea what it is, probably you don't need it.
-    pub fn share_id(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
-        let Some(vss_setup) = self.vss_setup.as_ref() else {
-            return if usize::from(j) < self.public_shares.len() {
-                #[allow(clippy::expect_used)]
-                Some(
-                    NonZero::from_scalar(Scalar::one() + Scalar::from(j))
-                        .expect("1 + i_u16 is guaranteed to be nonzero"),
-                )
-            } else {
-                None
-            };
-        };
-        vss_setup.I.get(usize::from(j)).copied()
-    }
-}
-
 impl<E: Curve> DirtyKeyInfo<E> {
     /// Returns share index of j-th signer
     ///

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -22,7 +22,7 @@ use generic_ec_zkp::polynomial::lagrange_coefficient;
 mod utils;
 mod valid;
 
-pub use self::valid::{Valid, Validate, ValidateError, ValidateFromParts};
+pub use self::valid::{Valid, ValidProjection, Validate, ValidateError, ValidateFromParts};
 
 /// Core key share
 ///
@@ -338,6 +338,34 @@ impl<E: Curve> CoreKeyShare<E> {
         self.shared_public_key
     }
 }
+
+impl<E: Curve> From<&DirtyCoreKeyShare<E>> for DirtyKeyInfo<E> {
+    fn from(key_share: &DirtyCoreKeyShare<E>) -> Self {
+        DirtyKeyInfo {
+            curve: key_share.curve,
+            shared_public_key: key_share.shared_public_key,
+            public_shares: key_share.public_shares.clone(),
+            vss_setup: key_share.vss_setup.clone(),
+            #[cfg(feature = "hd-wallets")]
+            chain_code: key_share.chain_code,
+        }
+    }
+}
+impl<E: Curve> From<DirtyCoreKeyShare<E>> for DirtyKeyInfo<E> {
+    fn from(key_share: DirtyCoreKeyShare<E>) -> Self {
+        DirtyKeyInfo {
+            curve: key_share.curve,
+            shared_public_key: key_share.shared_public_key,
+            public_shares: key_share.public_shares,
+            vss_setup: key_share.vss_setup,
+            #[cfg(feature = "hd-wallets")]
+            chain_code: key_share.chain_code,
+        }
+    }
+}
+
+impl<E: Curve> ValidProjection<DirtyCoreKeyShare<E>> for DirtyKeyInfo<E> {}
+impl<E: Curve> ValidProjection<&DirtyCoreKeyShare<E>> for DirtyKeyInfo<E> {}
 
 /// Error indicating that key share is not valid
 #[derive(Debug, thiserror::Error)]

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -121,6 +121,7 @@ pub struct DirtyCoreKeyShare<E: Curve> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound = ""))]
+#[cfg_attr(feature = "udigest", derive(udigest::Digestable))]
 /// Secret sharing setup of a key
 pub struct VssSetup<E: Curve> {
     /// Threshold parameter
@@ -140,8 +141,10 @@ pub struct VssSetup<E: Curve> {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound = ""))]
+#[cfg_attr(feature = "udigest", derive(udigest::Digestable))]
 pub struct DirtyKeyInfo<E: Curve> {
     /// Guard that ensures curve consistency for deseraization
+    #[cfg_attr(feature = "udigest", udigest(with = utils::encoding::curve_name))]
     pub curve: CurveName<E>,
     /// Public key corresponding to shared secret key. Corresponds to _X_ in paper.
     #[cfg_attr(feature = "serde", serde(with = "As::<generic_ec::serde::Compact>"))]
@@ -163,6 +166,7 @@ pub struct DirtyKeyInfo<E: Curve> {
         serde(default),
         serde(with = "As::<Option<utils::HexOrBin>>")
     )]
+    #[cfg_attr(feature = "udigest", udigest(with = utils::encoding::maybe_bytes))]
     pub chain_code: Option<slip_10::ChainCode>,
 }
 

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -90,8 +90,6 @@ use serde_with::As;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound = ""))]
 pub struct DirtyCoreKeyShare<E: Curve> {
-    /// Guard that ensures curve consistency for deseraization
-    pub curve: CurveName<E>,
     /// Index of local party in key generation protocol
     pub i: u16,
     /// Public key info
@@ -111,6 +109,9 @@ pub struct DirtyCoreKeyShare<E: Curve> {
 #[cfg_attr(feature = "serde", serde(bound = ""))]
 #[cfg_attr(feature = "udigest", derive(udigest::Digestable))]
 pub struct DirtyKeyInfo<E: Curve> {
+    /// Guard that ensures curve consistency for deseraization
+    #[cfg_attr(feature = "udigest", udigest(with = utils::encoding::curve_name))]
+    pub curve: CurveName<E>,
     /// Public key corresponding to shared secret key. Corresponds to _X_ in paper.
     #[cfg_attr(feature = "serde", serde(with = "As::<generic_ec::serde::Compact>"))]
     pub shared_public_key: Point<E>,
@@ -185,12 +186,7 @@ impl<E: Curve> ValidateFromParts<(u16, DirtyKeyInfo<E>, SecretScalar<E>)> for Di
     }
 
     fn from_parts((i, key_info, x): (u16, DirtyKeyInfo<E>, SecretScalar<E>)) -> Self {
-        Self {
-            curve: Default::default(),
-            i,
-            key_info,
-            x,
-        }
+        Self { i, key_info, x }
     }
 }
 

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -281,6 +281,54 @@ fn validate_non_vss_key_info<E: Curve>(
     Ok(())
 }
 
+impl<E: Curve> DirtyCoreKeyShare<E> {
+    /// Returns share index of j-th signer
+    ///
+    /// * For additive shares, share id is `j+1`
+    /// * For VSS-shares, share id is scalar $I_j$ such that $x_j = F(I_j)$ where
+    ///   $F(x)$ is polynomial co-shared by the signers
+    ///
+    /// Note: if you have no idea what it is, probably you don't need it.
+    pub fn share_id(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
+        let Some(vss_setup) = self.vss_setup.as_ref() else {
+            return if usize::from(j) < self.public_shares.len() {
+                #[allow(clippy::expect_used)]
+                Some(
+                    NonZero::from_scalar(Scalar::one() + Scalar::from(j))
+                        .expect("1 + i_u16 is guaranteed to be nonzero"),
+                )
+            } else {
+                None
+            };
+        };
+        vss_setup.I.get(usize::from(j)).copied()
+    }
+}
+
+impl<E: Curve> DirtyKeyInfo<E> {
+    /// Returns share index of j-th signer
+    ///
+    /// * For additive shares, share id is `j+1`
+    /// * For VSS-shares, share id is scalar $I_j$ such that $x_j = F(I_j)$ where
+    ///   $F(x)$ is polynomial co-shared by the signers
+    ///
+    /// Note: if you have no idea what it is, probably you don't need it.
+    pub fn share_id(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
+        let Some(vss_setup) = self.vss_setup.as_ref() else {
+            return if usize::from(j) < self.public_shares.len() {
+                #[allow(clippy::expect_used)]
+                Some(
+                    NonZero::from_scalar(Scalar::one() + Scalar::from(j))
+                        .expect("1 + i_u16 is guaranteed to be nonzero"),
+                )
+            } else {
+                None
+            };
+        };
+        vss_setup.I.get(usize::from(j)).copied()
+    }
+}
+
 #[cfg(feature = "hd-wallets")]
 impl<E: Curve> DirtyCoreKeyShare<E> {
     /// Checks whether the key is HD-capable

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -291,18 +291,17 @@ impl<E: Curve> DirtyKeyInfo<E> {
     ///
     /// Note: if you have no idea what it is, probably you don't need it.
     pub fn share_id(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
-        let Some(vss_setup) = self.vss_setup.as_ref() else {
-            return if usize::from(j) < self.public_shares.len() {
-                #[allow(clippy::expect_used)]
-                Some(
-                    NonZero::from_scalar(Scalar::one() + Scalar::from(j))
-                        .expect("1 + i_u16 is guaranteed to be nonzero"),
-                )
-            } else {
-                None
-            };
-        };
-        vss_setup.I.get(usize::from(j)).copied()
+        if let Some(vss_setup) = self.vss_setup.as_ref() {
+            vss_setup.I.get(usize::from(j)).copied()
+        } else if usize::from(j) < self.public_shares.len() {
+            #[allow(clippy::expect_used)]
+            Some(
+                NonZero::from_scalar(Scalar::one() + Scalar::from(j))
+                    .expect("1 + i_u16 is guaranteed to be nonzero"),
+            )
+        } else {
+            None
+        }
     }
 }
 

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -169,6 +169,31 @@ impl<E: Curve> Validate for DirtyCoreKeyShare<E> {
     }
 }
 
+impl<E: Curve> ValidateFromParts<(u16, DirtyKeyInfo<E>, SecretScalar<E>)> for DirtyCoreKeyShare<E> {
+    fn validate_parts(
+        (i, key_info, x): &(u16, DirtyKeyInfo<E>, SecretScalar<E>),
+    ) -> Result<(), Self::Error> {
+        let party_public_share = key_info
+            .public_shares
+            .get(usize::from(*i))
+            .ok_or(InvalidShareReason::PartyIndexOutOfBounds)?;
+        if *party_public_share != Point::generator() * x {
+            return Err(InvalidShareReason::PartySecretShareDoesntMatchPublicShare.into());
+        }
+
+        Ok(())
+    }
+
+    fn from_parts((i, key_info, x): (u16, DirtyKeyInfo<E>, SecretScalar<E>)) -> Self {
+        Self {
+            curve: Default::default(),
+            i,
+            key_info,
+            x,
+        }
+    }
+}
+
 impl<E: Curve> Validate for DirtyKeyInfo<E> {
     type Error = InvalidCoreShare;
 

--- a/key-share/src/lib.rs
+++ b/key-share/src/lib.rs
@@ -283,14 +283,15 @@ fn validate_non_vss_key_info<E: Curve>(
 }
 
 impl<E: Curve> DirtyKeyInfo<E> {
-    /// Returns share index of j-th signer
+    /// Returns share preimage associated with j-th signer
     ///
-    /// * For additive shares, share id is `j+1`
-    /// * For VSS-shares, share id is scalar $I_j$ such that $x_j = F(I_j)$ where
-    ///   $F(x)$ is polynomial co-shared by the signers
+    /// * For additive shares, share preimage is defined as `j+1`
+    /// * For VSS-shares, share preimage is scalar $I_j$ such that $x_j = F(I_j)$ where
+    ///   $F(x)$ is polynomial co-shared by the signers and $x_j$ is secret share of j-th
+    ///   signer
     ///
     /// Note: if you have no idea what it is, probably you don't need it.
-    pub fn share_id(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
+    pub fn share_preimage(&self, j: u16) -> Option<NonZero<Scalar<E>>> {
         if let Some(vss_setup) = self.vss_setup.as_ref() {
             vss_setup.I.get(usize::from(j)).copied()
         } else if usize::from(j) < self.public_shares.len() {

--- a/key-share/src/utils.rs
+++ b/key-share/src/utils.rs
@@ -12,6 +12,13 @@ use hex as _;
 
 #[cfg(feature = "udigest")]
 pub mod encoding {
+    pub fn curve_name<B: udigest::Buffer, E: generic_ec::Curve>(
+        _value: &generic_ec::serde::CurveName<E>,
+        encoder: udigest::encoding::EncodeValue<B>,
+    ) {
+        encoder.encode_leaf_value(E::CURVE_NAME)
+    }
+
     #[cfg(feature = "hd-wallets")]
     pub fn maybe_bytes<B: udigest::Buffer>(
         m: &Option<impl AsRef<[u8]>>,

--- a/key-share/src/utils.rs
+++ b/key-share/src/utils.rs
@@ -9,3 +9,22 @@ pub use hex_or_bin::HexOrBin;
 // `hd-wallets` is off, unused dependency is introduced.
 #[cfg(all(feature = "serde", not(feature = "hd-wallets")))]
 use hex as _;
+
+#[cfg(feature = "udigest")]
+pub mod encoding {
+    pub fn curve_name<B: udigest::Buffer, E: generic_ec::Curve>(
+        _value: &generic_ec::serde::CurveName<E>,
+        encoder: udigest::encoding::EncodeValue<B>,
+    ) {
+        encoder.encode_leaf_value(E::CURVE_NAME)
+    }
+
+    #[cfg(feature = "hd-wallets")]
+    pub fn maybe_bytes<B: udigest::Buffer>(
+        m: &Option<impl AsRef<[u8]>>,
+        encoder: udigest::encoding::EncodeValue<B>,
+    ) {
+        use udigest::Digestable;
+        m.as_ref().map(udigest::Bytes).unambiguously_encode(encoder)
+    }
+}

--- a/key-share/src/utils.rs
+++ b/key-share/src/utils.rs
@@ -12,13 +12,6 @@ use hex as _;
 
 #[cfg(feature = "udigest")]
 pub mod encoding {
-    pub fn curve_name<B: udigest::Buffer, E: generic_ec::Curve>(
-        _value: &generic_ec::serde::CurveName<E>,
-        encoder: udigest::encoding::EncodeValue<B>,
-    ) {
-        encoder.encode_leaf_value(E::CURVE_NAME)
-    }
-
     #[cfg(feature = "hd-wallets")]
     pub fn maybe_bytes<B: udigest::Buffer>(
         m: &Option<impl AsRef<[u8]>>,

--- a/key-share/src/valid.rs
+++ b/key-share/src/valid.rs
@@ -7,12 +7,12 @@ use std::fmt;
 /// `Valid<T>` provides only immutable access to `T`. For instance, if you want to change content of `T`, you
 /// need to [deconstruct](Valid::into_inner) it, do necessary modifications, and then validate it again.
 ///
-/// ## Transitive "validness" through `AsRef`
+/// ## Transitive "valideness" through `AsRef`
 /// `Valid<T>` assumes that if `T` implements `AsRef<K>` and `K` can be validated (i.e. `K` implements [`Validate`]),
 /// then `K` has been validated when `T` was validated. Thus, if you have value of type `Valid<T>`, you can obtain
 /// `&Valid<K>` via `AsRef` trait.
 ///
-/// Example of transitive validness is demostrated below:
+/// Example of transitive valideness is demostrated below:
 /// ```rust
 /// use key_share::{Validate, Valid};
 ///

--- a/key-share/src/valid.rs
+++ b/key-share/src/valid.rs
@@ -127,6 +127,7 @@ where
     /// Performs a debug assertion that `T` is validated
     fn from_ref_unchecked(value: &T) -> &Self {
         #[cfg(debug_assertions)]
+        #[allow(clippy::expect_used)]
         value
             .is_valid()
             .expect("debug assertions: value is invalid, but was assumed to be valid");

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ let # Rust
 in pkgs.stdenv.mkDerivation {
   name = "signers-env";
   nativeBuildInputs = [
-    rust pkgs.rust-analyzer tex
+    rust pkgs.rust-analyzer tex pkgs.gnum4
   ];
   buildInputs = lib.optionals isDarwin [pkgs.darwin.apple_sdk.frameworks.Security];
 }


### PR DESCRIPTION
* `KeyInfo` contains public information about the key. It's useful in FROST.
* `Valid<T>` now transitively trusts that if `T` contains `K`, then `K` must have been validated when `T` was validated. That allows us to have `as_ref :: &Valid<T> -> &Valid<K>`