### PR TITLE
Prohibit `sk=0` and `x_j=0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "cggmp21-keygen",
  "digest",
  "futures",
- "generic-ec 0.2.0",
+ "generic-ec",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -301,7 +301,7 @@ version = "0.1.0"
 dependencies = [
  "digest",
  "futures",
- "generic-ec 0.2.0",
+ "generic-ec",
  "generic-ec-zkp",
  "hex",
  "key-share",
@@ -323,7 +323,7 @@ dependencies = [
  "bpaf",
  "cggmp21",
  "futures",
- "generic-ec 0.2.0",
+ "generic-ec",
  "generic-tests",
  "lazy_static",
  "rand",
@@ -892,19 +892,6 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20aec40cfb745f7af3d8e889bbfedbe1565cd383a645ceae86b32e8766d5060"
-dependencies = [
- "generic-ec-core",
- "phantom-type 0.4.2",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f315ffeaae6a05691c5a27028b4ae960d3a430e406d0109ff8502e2f84ae97b"
@@ -961,7 +948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b631ea71fa0294e80d479c5b952e276776c9abf1b1a542b48e66b83fe1828c"
 dependencies = [
  "generic-array",
- "generic-ec 0.2.0",
+ "generic-ec",
  "rand_core",
  "serde",
  "subtle",
@@ -1301,7 +1288,7 @@ dependencies = [
 name = "key-share"
 version = "0.1.0"
 dependencies = [
- "generic-ec 0.2.0",
+ "generic-ec",
  "generic-ec-zkp",
  "hex",
  "rand_core",
@@ -1431,12 +1418,13 @@ dependencies = [
 
 [[package]]
 name = "paillier-zk"
-version = "0.1.0"
-source = "git+https://github.com/dfns/paillier-zk?branch=update-generic-ec#283e3d60d595d696bfba56c86a5af22acc694c4f"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390990e7d2f9a189043a2ce042cce3107955046561d5a89ae717dfc31b9c1ca4"
 dependencies = [
  "digest",
  "fast-paillier",
- "generic-ec 0.2.0",
+ "generic-ec",
  "rand_core",
  "rug",
  "serde",
@@ -2029,12 +2017,12 @@ dependencies = [
 
 [[package]]
 name = "slip-10"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4670651d286d5714497971c12d36b83d75679c39da5d5ed757ff5e1e1d45855c"
+checksum = "f20f0918d675ab26ca9fa3e2c42548356f54b7a09fb4633313756522ddd59f75"
 dependencies = [
  "generic-array",
- "generic-ec 0.1.4",
+ "generic-ec",
  "hmac",
  "sha2",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "cggmp21-keygen",
  "digest",
  "futures",
- "generic-ec",
+ "generic-ec 0.2.0",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -301,7 +301,7 @@ version = "0.1.0"
 dependencies = [
  "digest",
  "futures",
- "generic-ec",
+ "generic-ec 0.2.0",
  "generic-ec-zkp",
  "hex",
  "key-share",
@@ -323,7 +323,7 @@ dependencies = [
  "bpaf",
  "cggmp21",
  "futures",
- "generic-ec",
+ "generic-ec 0.2.0",
  "generic-tests",
  "lazy_static",
  "rand",
@@ -893,7 +893,21 @@ dependencies = [
 [[package]]
 name = "generic-ec"
 version = "0.1.4"
-source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20aec40cfb745f7af3d8e889bbfedbe1565cd383a645ceae86b32e8766d5060"
+dependencies = [
+ "generic-ec-core",
+ "phantom-type 0.4.2",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f315ffeaae6a05691c5a27028b4ae960d3a430e406d0109ff8502e2f84ae97b"
 dependencies = [
  "generic-ec-core",
  "generic-ec-curves",
@@ -909,8 +923,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-core"
-version = "0.1.2"
-source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cab102fc88bfc017c16e69d21edae6f41ab58bfe69eed09ed0a2cf10ec923f"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -921,8 +936,9 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-curves"
-version = "0.1.3"
-source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a133d38cde4fef7aea4e367ca51f291db0248495a424ec4208cdace08ba59f4"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek",
@@ -940,12 +956,12 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-zkp"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98645d68f62951789a4aec46ef4416878c2827b2353f5267cf96b096eae60d9"
+checksum = "a9b631ea71fa0294e80d479c5b952e276776c9abf1b1a542b48e66b83fe1828c"
 dependencies = [
  "generic-array",
- "generic-ec",
+ "generic-ec 0.2.0",
  "rand_core",
  "serde",
  "subtle",
@@ -1285,7 +1301,7 @@ dependencies = [
 name = "key-share"
 version = "0.1.0"
 dependencies = [
- "generic-ec",
+ "generic-ec 0.2.0",
  "generic-ec-zkp",
  "hex",
  "rand_core",
@@ -1416,12 +1432,11 @@ dependencies = [
 [[package]]
 name = "paillier-zk"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4956496b1cb7ecf45e86844ae50a5c0ade430dd4d491de8d020adb95ca6f328"
+source = "git+https://github.com/dfns/paillier-zk?branch=update-generic-ec#283e3d60d595d696bfba56c86a5af22acc694c4f"
 dependencies = [
  "digest",
  "fast-paillier",
- "generic-ec",
+ "generic-ec 0.2.0",
  "rand_core",
  "rug",
  "serde",
@@ -2019,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4670651d286d5714497971c12d36b83d75679c39da5d5ed757ff5e1e1d45855c"
 dependencies = [
  "generic-array",
- "generic-ec",
+ "generic-ec 0.1.4",
  "hmac",
  "sha2",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,12 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
-
-[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,9 +391,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -448,6 +442,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "group",
+ "platforms",
+ "rand_core",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -536,7 +559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -558,23 +580,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
 ]
 
 [[package]]
@@ -607,8 +614,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
- "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -734,6 +739,12 @@ dependencies = [
  "quote",
  "syn 1.0.101",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "fixed-hash"
@@ -881,13 +892,11 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61335b136fd9559af4284e642c081c2845e1f92650909eeec1fb47a8945a3f7"
+version = "0.1.4"
+source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
 dependencies = [
  "generic-ec-core",
  "generic-ec-curves",
- "getrandom",
  "hex",
  "phantom-type 0.4.2",
  "rand_core",
@@ -901,8 +910,7 @@ dependencies = [
 [[package]]
 name = "generic-ec-core"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1193740c17f0324ea5d7db0635230f7538e5d33e0f9732af92d3f9fd4b87663e"
+source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -913,13 +921,14 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-curves"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01b7dc4d4f06522f1c2bd8170c978f555a317c0e6c6f141b8b4f3db63c8c302"
+version = "0.1.3"
+source = "git+https://github.com/dfns/generic-ec?branch=nonzero-cmp#59d850ee920e0b34219b348a5a5066034de47db9"
 dependencies = [
  "crypto-bigint",
+ "curve25519-dalek",
  "elliptic-curve",
  "generic-ec-core",
+ "group",
  "k256",
  "p256",
  "rand_core",
@@ -1260,11 +1269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1299,9 +1304,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "link-cplusplus"
@@ -1404,10 +1409,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -1468,15 +1471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,14 +1507,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
+name = "platforms"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "ppv-lite86"
@@ -1859,7 +1849,6 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -2015,16 +2004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,16 +2040,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spki"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stark-curve"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "tests",
 ]
 
+[patch.crates-io.generic-ec]
+git = "https://github.com/dfns/generic-ec"
+branch = "nonzero-cmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
     "tests",
 ]
 
-[patch.crates-io.generic-ec]
-git = "https://github.com/dfns/generic-ec"
-branch = "nonzero-cmp"
+[patch.crates-io.paillier-zk]
+git = "https://github.com/dfns/paillier-zk"
+branch = "update-generic-ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ members = [
     "tests",
 ]
 
-[patch.crates-io.paillier-zk]
-git = "https://github.com/dfns/paillier-zk"
-branch = "update-generic-ec"

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mpc", "dkg", "threshold-signatures", "tss", "ecdsa", "t-ecdsa"]
 
 [dependencies]
 key-share = { path = "../key-share", version = "0.1", features = ["serde"] }
-slip-10 = { version = "0.1", optional = true }
+slip-10 = { version = "0.2", optional = true }
 
 generic-ec = { version = "0.2", features = ["serde", "udigest"] }
 generic-ec-zkp = { version = "0.2", features = ["serde", "udigest"] }

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["mpc", "dkg", "threshold-signatures", "tss", "ecdsa", "t-ecdsa"]
 key-share = { path = "../key-share", version = "0.1", features = ["serde"] }
 slip-10 = { version = "0.1", optional = true }
 
-generic-ec = { version = "0.1", features = ["serde", "udigest"] }
-generic-ec-zkp = { version = "0.1", features = ["serde", "udigest"] }
+generic-ec = { version = "0.2", features = ["serde", "udigest"] }
+generic-ec-zkp = { version = "0.2", features = ["serde", "udigest"] }
 udigest = { version = "0.1", features = ["std", "derive"]}
 
 round-based = { version = "0.2", features = ["derive"] }

--- a/cggmp21-keygen/src/lib.rs
+++ b/cggmp21-keygen/src/lib.rs
@@ -307,6 +307,10 @@ enum Bug {
     #[cfg(feature = "hd-wallets")]
     #[error("chain code is missing although we checked that it should be present")]
     NoChainCode,
+    #[error("key share of one of the signers is zero - probability of that is negligible")]
+    ZeroShare,
+    #[error("shared public key is zero - probability of that is negligible")]
+    ZeroPk,
 }
 
 /// Distributed key generation protocol

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -15,8 +15,8 @@ readme = "../README.md"
 cggmp21-keygen = { path = "../cggmp21-keygen", version = "0.1" }
 key-share = { path = "../key-share", version = "0.1" }
 
-generic-ec = { version = "0.1", features = ["serde", "udigest"] }
-generic-ec-zkp = { version = "0.1", features = ["serde", "udigest"] }
+generic-ec = { version = "0.2", features = ["serde", "udigest"] }
+generic-ec-zkp = { version = "0.2", features = ["serde", "udigest"] }
 round-based = { version = "0.2", features = ["derive"] }
 
 paillier-zk = { version = "0.1", features = ["serde"] }

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -19,7 +19,7 @@ generic-ec = { version = "0.2", features = ["serde", "udigest"] }
 generic-ec-zkp = { version = "0.2", features = ["serde", "udigest"] }
 round-based = { version = "0.2", features = ["derive"] }
 
-paillier-zk = { version = "0.1", features = ["serde"] }
+paillier-zk = { version = "0.2", features = ["serde"] }
 udigest = { version = "0.1", features = ["std", "derive"]}
 
 digest = "0.10"
@@ -35,7 +35,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_with = { version = "2" }
 hex = { version = "0.4", default-features = false, features = ["serde"] }
 
-slip-10 = { version = "0.1", optional = true, features = ["std"] }
+slip-10 = { version = "0.2", optional = true, features = ["std"] }
 
 [dev-dependencies]
 round-based = { version = "0.2", features = ["derive", "dev"] }

--- a/cggmp21/src/key_refresh.rs
+++ b/cggmp21/src/key_refresh.rs
@@ -326,6 +326,8 @@ enum Bug {
     BuildMultiexpTables(#[source] crate::key_share::InvalidKeyShare),
     #[error("couldn't build CRT")]
     BuildCrt,
+    #[error("updated share is zero - probability of that is negligible")]
+    ZeroShare,
 }
 
 /// Error indicating that protocol was aborted by malicious party

--- a/cggmp21/src/key_share.rs
+++ b/cggmp21/src/key_share.rs
@@ -3,7 +3,7 @@
 use std::ops;
 use std::sync::Arc;
 
-use generic_ec::{Curve, Point, SecretScalar};
+use generic_ec::{Curve, NonZero, Point, SecretScalar};
 use paillier_zk::paillier_encryption_in_range as π_enc;
 use paillier_zk::rug::{Complete, Integer};
 use serde::{Deserialize, Serialize};
@@ -327,7 +327,7 @@ pub trait AnyKeyShare<E: Curve>: AsRef<IncompleteKeyShare<E>> {
     }
 
     /// Returns public key shared by signers
-    fn shared_public_key(&self) -> Point<E> {
+    fn shared_public_key(&self) -> NonZero<Point<E>> {
         self.as_ref().shared_public_key
     }
 }

--- a/cggmp21/src/trusted_dealer.rs
+++ b/cggmp21/src/trusted_dealer.rs
@@ -11,9 +11,9 @@
 //! # use rand::rngs::OsRng;
 //! # let mut rng = OsRng;
 //! use cggmp21::{supported_curves::Secp256k1, security_level::SecurityLevel128};
-//! use cggmp21::generic_ec::SecretScalar;
+//! use cggmp21::generic_ec::{SecretScalar, NonZero};
 //!
-//! let secret_key_to_be_imported = SecretScalar::<Secp256k1>::random(&mut rng);
+//! let secret_key_to_be_imported = NonZero::<SecretScalar<Secp256k1>>::random(&mut rng);
 //!
 //! let key_shares = cggmp21::trusted_dealer::builder::<Secp256k1, SecurityLevel128>(5)
 //!     .set_threshold(Some(3))

--- a/cggmp21/src/trusted_dealer.rs
+++ b/cggmp21/src/trusted_dealer.rs
@@ -24,7 +24,7 @@
 
 use std::{iter, marker::PhantomData};
 
-use generic_ec::{Curve, SecretScalar};
+use generic_ec::{Curve, NonZero, SecretScalar};
 use paillier_zk::{
     rug::{Complete, Integer},
     IntegerExt,
@@ -98,7 +98,7 @@ impl<E: Curve, L: SecurityLevel> TrustedDealerBuilder<E, L> {
     /// Sets shared secret key to be generated
     ///
     /// Resulting key shares will share specified secret key.
-    pub fn set_shared_secret_key(self, sk: SecretScalar<E>) -> Self {
+    pub fn set_shared_secret_key(self, sk: NonZero<SecretScalar<E>>) -> Self {
         Self {
             inner: self.inner.set_shared_secret_key(sk),
             ..self

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -15,7 +15,7 @@ generic-ec = "0.2"
 generic-ec-zkp = "0.2"
 rand_core = { version = "0.6", optional = true }
 
-slip-10 = { version = "0.1", optional = true, features = ["std"] }
+slip-10 = { version = "0.2", optional = true, features = ["std"] }
 udigest = { version = "0.1", default-features = false, features = ["derive"], optional = true }
 
 serde = { version = "1", features = ["derive"], optional = true }

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["mpc", "threshold-signatures", "tss"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = "0.1.3"
-generic-ec-zkp = "0.1"
+generic-ec = "0.2"
+generic-ec-zkp = "0.2"
 rand_core = { version = "0.6", optional = true }
 
 slip-10 = { version = "0.1", optional = true, features = ["std"] }

--- a/key-share/src/trusted_dealer.rs
+++ b/key-share/src/trusted_dealer.rs
@@ -20,7 +20,7 @@
 //! # Ok::<_, key_share::trusted_dealer::TrustedDealerError>(())
 //! ```
 
-use generic_ec::{Curve, Point, Scalar, SecretScalar};
+use generic_ec::{Curve, NonZero, Point, Scalar, SecretScalar};
 
 use crate::{CoreKeyShare, VssSetup};
 
@@ -37,7 +37,7 @@ pub fn builder<E: Curve>(n: u16) -> TrustedDealerBuilder<E> {
 pub struct TrustedDealerBuilder<E: Curve> {
     t: Option<u16>,
     n: u16,
-    shared_secret_key: Option<SecretScalar<E>>,
+    shared_secret_key: Option<NonZero<SecretScalar<E>>>,
     #[cfg(feature = "hd-wallets")]
     enable_hd: bool,
 }
@@ -75,7 +75,7 @@ impl<E: Curve> TrustedDealerBuilder<E> {
     /// Sets shared secret key to be generated
     ///
     /// Resulting key shares will share specified secret key.
-    pub fn set_shared_secret_key(self, sk: SecretScalar<E>) -> Self {
+    pub fn set_shared_secret_key(self, sk: NonZero<SecretScalar<E>>) -> Self {
         Self {
             shared_secret_key: Some(sk),
             ..self
@@ -101,33 +101,44 @@ impl<E: Curve> TrustedDealerBuilder<E> {
     ) -> Result<Vec<CoreKeyShare<E>>, TrustedDealerError> {
         let shared_secret_key = self
             .shared_secret_key
-            .unwrap_or_else(|| SecretScalar::random(rng));
+            .unwrap_or_else(|| NonZero::<SecretScalar<_>>::random(rng));
+        let shared_public_key = Point::generator() * &shared_secret_key;
         let key_shares_indexes = (1..=self.n)
             .map(|i| generic_ec::NonZero::from_scalar(Scalar::from(i)))
             .collect::<Option<Vec<_>>>()
             .ok_or(Reason::DeriveKeyShareIndex)?;
-        let (shared_public_key, secret_shares) = if let Some(t) = self.t {
+        let secret_shares = if let Some(t) = self.t {
             let f = generic_ec_zkp::polynomial::Polynomial::sample_with_const_term(
                 rng,
                 usize::from(t) - 1,
                 shared_secret_key,
             );
-            let pk = Point::generator() * f.value::<_, Scalar<_>>(&Scalar::zero());
+            debug_assert_eq!(
+                shared_public_key,
+                Point::generator() * f.value::<_, Scalar<_>>(&Scalar::zero())
+            );
             let shares = key_shares_indexes
                 .iter()
                 .map(|I_i| f.value(I_i))
                 .map(|mut x_i| SecretScalar::new(&mut x_i))
-                .collect::<Vec<_>>();
-            (pk, shares)
+                .map(|x| NonZero::from_secret_scalar(x).ok_or(Reason::ZeroShare))
+                .collect::<Result<Vec<_>, _>>()?;
+            shares
         } else {
-            let mut shares = std::iter::repeat_with(|| SecretScalar::<E>::random(rng))
+            let mut shares = std::iter::repeat_with(|| NonZero::<SecretScalar<E>>::random(rng))
                 .take((self.n - 1).into())
                 .collect::<Vec<_>>();
-            shares.push(SecretScalar::new(
-                &mut (shared_secret_key - shares.iter().sum::<Scalar<E>>()),
-            ));
-            let pk = shares.iter().sum::<Scalar<E>>() * Point::generator();
-            (pk, shares)
+            shares.push(
+                NonZero::from_secret_scalar(SecretScalar::new(
+                    &mut (shared_secret_key - shares.iter().sum::<SecretScalar<E>>()),
+                ))
+                .ok_or(Reason::ZeroShare)?,
+            );
+            debug_assert_eq!(
+                shared_public_key,
+                shares.iter().sum::<SecretScalar<E>>() * Point::generator()
+            );
+            shares
         };
 
         let public_shares = secret_shares
@@ -181,4 +192,6 @@ enum Reason {
     InvalidKeyShare(#[source] crate::InvalidCoreShare),
     #[error("deriving key share index failed")]
     DeriveKeyShareIndex,
+    #[error("randomly generated share is zero - probability of that is negligible")]
+    ZeroShare,
 }

--- a/key-share/src/trusted_dealer.rs
+++ b/key-share/src/trusted_dealer.rs
@@ -9,9 +9,9 @@
 //! ```rust,no_run
 //! # use rand_core::OsRng;
 //! # let mut rng = OsRng;
-//! use generic_ec::{curves::Secp256k1, SecretScalar};
+//! use generic_ec::{curves::Secp256k1, SecretScalar, NonZero};
 //!
-//! let secret_key_to_be_imported = SecretScalar::<Secp256k1>::random(&mut rng);
+//! let secret_key_to_be_imported = NonZero::<SecretScalar<Secp256k1>>::random(&mut rng);
 //!
 //! let key_shares = key_share::trusted_dealer::builder::<Secp256k1>(5)
 //!     .set_threshold(Some(3))

--- a/key-share/src/trusted_dealer.rs
+++ b/key-share/src/trusted_dealer.rs
@@ -117,13 +117,13 @@ impl<E: Curve> TrustedDealerBuilder<E> {
                 shared_public_key,
                 Point::generator() * f.value::<_, Scalar<_>>(&Scalar::zero())
             );
-            let shares = key_shares_indexes
+
+            key_shares_indexes
                 .iter()
                 .map(|I_i| f.value(I_i))
                 .map(|mut x_i| SecretScalar::new(&mut x_i))
                 .map(|x| NonZero::from_secret_scalar(x).ok_or(Reason::ZeroShare))
-                .collect::<Result<Vec<_>, _>>()?;
-            shares
+                .collect::<Result<Vec<_>, _>>()?
         } else {
             let mut shares = std::iter::repeat_with(|| NonZero::<SecretScalar<E>>::random(rng))
                 .take((self.n - 1).into())

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,7 +21,7 @@ rand_chacha = "0.3"
 sha2 = "0.10"
 
 round-based = { version = "0.2", features = ["derive", "dev"] }
-generic-ec = { version = "0.1", features = ["serde", "all-curves"] }
+generic-ec = { version = "0.2", features = ["serde", "all-curves"] }
 
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"

--- a/tests/tests/it/pipeline.rs
+++ b/tests/tests/it/pipeline.rs
@@ -1,6 +1,6 @@
 #[generic_tests::define(attrs(tokio::test, test_case::case, cfg_attr))]
 mod generic {
-    use generic_ec::{Curve, Point};
+    use generic_ec::{Curve, NonZero, Point};
     use rand::{seq::SliceRandom, Rng, RngCore};
     use rand_dev::DevRng;
     use round_based::simulation::Simulation;
@@ -167,10 +167,13 @@ mod generic {
 
         #[cfg(feature = "hd-wallets")]
         let public_key = if let Some(path) = &derivation_path {
-            shares[0]
-                .derive_child_public_key(path.iter().cloned())
-                .unwrap()
-                .public_key
+            NonZero::from_point(
+                shares[0]
+                    .derive_child_public_key(path.iter().cloned())
+                    .unwrap()
+                    .public_key,
+            )
+            .unwrap()
         } else {
             shares[0].shared_public_key
         };

--- a/tests/tests/it/signing.rs
+++ b/tests/tests/it/signing.rs
@@ -1,7 +1,7 @@
 #[generic_tests::define(attrs(tokio::test, test_case::case, cfg_attr))]
 mod generic {
     use cggmp21_tests::external_verifier::ExternalVerifier;
-    use generic_ec::{coords::HasAffineX, Curve, Point};
+    use generic_ec::{coords::HasAffineX, Curve, NonZero, Point};
     use rand::seq::SliceRandom;
     use rand::{Rng, RngCore};
     use rand_dev::DevRng;
@@ -93,10 +93,13 @@ mod generic {
 
         #[cfg(feature = "hd-wallets")]
         let public_key = if let Some(path) = &derivation_path {
-            shares[0]
-                .derive_child_public_key(path.iter().cloned())
-                .unwrap()
-                .public_key
+            NonZero::from_point(
+                shares[0]
+                    .derive_child_public_key(path.iter().cloned())
+                    .unwrap()
+                    .public_key,
+            )
+            .unwrap()
         } else {
             shares[0].shared_public_key
         };
@@ -194,10 +197,13 @@ mod generic {
 
         #[cfg(feature = "hd-wallets")]
         let public_key = if let Some(path) = &derivation_path {
-            shares[0]
-                .derive_child_public_key(path.iter().cloned())
-                .unwrap()
-                .public_key
+            NonZero::from_point(
+                shares[0]
+                    .derive_child_public_key(path.iter().cloned())
+                    .unwrap()
+                    .public_key,
+            )
+            .unwrap()
         } else {
             shares[0].shared_public_key
         };


### PR DESCRIPTION
Prohibit the key shares that contain zero public key / secret share / commitment to other signer share