### PR TITLE
Update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "cggmp21-keygen",
  "digest",
  "futures",
- "generic-ec 0.3.0",
+ "generic-ec",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -301,7 +301,7 @@ version = "0.2.0"
 dependencies = [
  "digest",
  "displaydoc",
- "generic-ec 0.3.0",
+ "generic-ec",
  "generic-ec-zkp",
  "hex",
  "key-share",
@@ -324,7 +324,7 @@ dependencies = [
  "cggmp21",
  "ciborium",
  "futures",
- "generic-ec 0.3.0",
+ "generic-ec",
  "generic-tests",
  "hex",
  "include_dir",
@@ -933,25 +933,12 @@ dependencies = [
 
 [[package]]
 name = "generic-ec"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0c68aa918e65f208d4d375ce7aed0d0c92c78cfa919f6efc8863190099080f"
-dependencies = [
- "generic-ec-core 0.1.3",
- "phantom-type 0.4.2",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c35601473af37794b53e8c7dc4a540a659d8de54c957990e88715b4037597d1"
 dependencies = [
  "curve25519-dalek",
- "generic-ec-core 0.2.0",
+ "generic-ec-core",
  "generic-ec-curves",
  "hex",
  "phantom-type 0.4.2",
@@ -960,18 +947,6 @@ dependencies = [
  "serde_with 2.3.3",
  "subtle",
  "udigest",
- "zeroize",
-]
-
-[[package]]
-name = "generic-ec-core"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cab102fc88bfc017c16e69d21edae6f41ab58bfe69eed09ed0a2cf10ec923f"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
  "zeroize",
 ]
 
@@ -996,7 +971,7 @@ checksum = "b5926949b758d01801c7edd75357495fe54c5fc25580a193de4c994c94d22307"
 dependencies = [
  "curve25519-dalek",
  "elliptic-curve",
- "generic-ec-core 0.2.0",
+ "generic-ec-core",
  "group",
  "k256",
  "p256",
@@ -1014,7 +989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae3a4e8ce33015cedc103b7c193c797baa318fa695a71e3ef3652197389d977"
 dependencies = [
  "generic-array",
- "generic-ec 0.3.0",
+ "generic-ec",
  "rand_core",
  "serde",
  "subtle",
@@ -1384,7 +1359,7 @@ name = "key-share"
 version = "0.2.3"
 dependencies = [
  "displaydoc",
- "generic-ec 0.3.0",
+ "generic-ec",
  "generic-ec-zkp",
  "hex",
  "rand_core",
@@ -1520,7 +1495,7 @@ checksum = "49e75f79f16fa844d601be6a49467068b0e329dc69e4466eeec66d23a6162825"
 dependencies = [
  "digest",
  "fast-paillier",
- "generic-ec 0.3.0",
+ "generic-ec",
  "rand_core",
  "rug",
  "serde",
@@ -2114,12 +2089,12 @@ dependencies = [
 
 [[package]]
 name = "slip-10"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20f0918d675ab26ca9fa3e2c42548356f54b7a09fb4633313756522ddd59f75"
+checksum = "6b92fadfb9de28645b655fb6508d8e5d433c024577d53d5c2501d808489bfb52"
 dependencies = [
  "generic-array",
- "generic-ec 0.2.3",
+ "generic-ec",
  "hmac",
  "sha2",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "key-share"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "displaydoc",
  "generic-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "cggmp21-keygen",
  "digest",
  "futures",
- "generic-ec",
+ "generic-ec 0.3.0",
  "generic-ec-zkp",
  "generic-tests",
  "hex",
@@ -301,7 +301,7 @@ version = "0.2.0"
 dependencies = [
  "digest",
  "displaydoc",
- "generic-ec",
+ "generic-ec 0.3.0",
  "generic-ec-zkp",
  "hex",
  "key-share",
@@ -324,7 +324,7 @@ dependencies = [
  "cggmp21",
  "ciborium",
  "futures",
- "generic-ec",
+ "generic-ec 0.3.0",
  "generic-tests",
  "hex",
  "include_dir",
@@ -937,7 +937,21 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af0c68aa918e65f208d4d375ce7aed0d0c92c78cfa919f6efc8863190099080f"
 dependencies = [
- "generic-ec-core",
+ "generic-ec-core 0.1.3",
+ "phantom-type 0.4.2",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c35601473af37794b53e8c7dc4a540a659d8de54c957990e88715b4037597d1"
+dependencies = [
+ "curve25519-dalek",
+ "generic-ec-core 0.2.0",
  "generic-ec-curves",
  "hex",
  "phantom-type 0.4.2",
@@ -957,6 +971,18 @@ checksum = "22cab102fc88bfc017c16e69d21edae6f41ab58bfe69eed09ed0a2cf10ec923f"
 dependencies = [
  "generic-array",
  "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-ec-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f156564cc8aa47456da807826b1a0aa9cf420474d9f41593ffbdde65133d4bea"
+dependencies = [
+ "generic-array",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -964,14 +990,13 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-curves"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a133d38cde4fef7aea4e367ca51f291db0248495a424ec4208cdace08ba59f4"
+checksum = "b5926949b758d01801c7edd75357495fe54c5fc25580a193de4c994c94d22307"
 dependencies = [
- "crypto-bigint",
  "curve25519-dalek",
  "elliptic-curve",
- "generic-ec-core",
+ "generic-ec-core 0.2.0",
  "group",
  "k256",
  "p256",
@@ -984,12 +1009,12 @@ dependencies = [
 
 [[package]]
 name = "generic-ec-zkp"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b631ea71fa0294e80d479c5b952e276776c9abf1b1a542b48e66b83fe1828c"
+checksum = "dae3a4e8ce33015cedc103b7c193c797baa318fa695a71e3ef3652197389d977"
 dependencies = [
  "generic-array",
- "generic-ec",
+ "generic-ec 0.3.0",
  "rand_core",
  "serde",
  "subtle",
@@ -1359,7 +1384,7 @@ name = "key-share"
 version = "0.2.3"
 dependencies = [
  "displaydoc",
- "generic-ec",
+ "generic-ec 0.3.0",
  "generic-ec-zkp",
  "hex",
  "rand_core",
@@ -1489,13 +1514,13 @@ dependencies = [
 
 [[package]]
 name = "paillier-zk"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390990e7d2f9a189043a2ce042cce3107955046561d5a89ae717dfc31b9c1ca4"
+checksum = "49e75f79f16fa844d601be6a49467068b0e329dc69e4466eeec66d23a6162825"
 dependencies = [
  "digest",
  "fast-paillier",
- "generic-ec",
+ "generic-ec 0.3.0",
  "rand_core",
  "rug",
  "serde",
@@ -2094,7 +2119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f20f0918d675ab26ca9fa3e2c42548356f54b7a09fb4633313756522ddd59f75"
 dependencies = [
  "generic-array",
- "generic-ec",
+ "generic-ec 0.2.3",
  "hmac",
  "sha2",
  "subtle",

--- a/cggmp21-keygen/CHANGELOG.md
+++ b/cggmp21-keygen/CHANGELOG.md
@@ -4,8 +4,10 @@
 * Make library `#![no_std]`-compatible and WASM-friendly [#100]
 * Provide sync API to carry out DKG protocol [#100]
 * Update `round-based` dep to `v0.3`
+* Update `generic-ec` and `slip-10` deps to latest version [#101]
 
 [#100]: https://github.com/dfns/cggmp21/pull/100
+[#101]: https://github.com/dfns/cggmp21/pull/101
 
 ## v0.1.0
 

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["mpc", "dkg", "threshold-signatures", "tss"]
 key-share = { path = "../key-share", version = "0.2", default-features = false, features = ["serde"] }
 slip-10 = { version = "0.2", default-features = false, optional = true }
 
-generic-ec = { version = "0.2", default-features = false, features = ["serde", "udigest"] }
-generic-ec-zkp = { version = "0.2", default-features = false, features = ["serde", "udigest"] }
+generic-ec = { version = "0.3", default-features = false, features = ["serde", "udigest"] }
+generic-ec-zkp = { version = "0.3", default-features = false, features = ["serde", "udigest"] }
 udigest = { version = "0.1", default-features = false, features = ["derive"]}
 
 round-based = { version = "0.3", default-features = false, features = ["derive"] }

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["mpc", "dkg", "threshold-signatures", "tss"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-key-share = { path = "../key-share", version = "0.2", default-features = false, features = ["serde"] }
+key-share = { path = "../key-share", version = "0.3", default-features = false, features = ["serde"] }
 slip-10 = { version = "0.3", default-features = false, optional = true }
 
 generic-ec = { version = "0.3", default-features = false, features = ["serde", "udigest"] }

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mpc", "dkg", "threshold-signatures", "tss"]
 
 [dependencies]
 key-share = { path = "../key-share", version = "0.2", default-features = false, features = ["serde"] }
-slip-10 = { version = "0.2", default-features = false, optional = true }
+slip-10 = { version = "0.3", default-features = false, optional = true }
 
 generic-ec = { version = "0.3", default-features = false, features = ["serde", "udigest"] }
 generic-ec-zkp = { version = "0.3", default-features = false, features = ["serde", "udigest"] }

--- a/cggmp21/CHANGELOG.md
+++ b/cggmp21/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## v0.3.0
 * Provide sync API to carry out provided protocols [#100]
-* Update `round-based` dep to `v0.3`
+* Update `round-based` dep to `v0.3` [#100]
+* Update `generic-ec`, `slip-10`, `paillier-zk` deps to latest version [#101]
+* Optimize key share verification and signing using new features of `generic-ec` [#101]
 
 [#100]: https://github.com/dfns/cggmp21/pull/100
+[#101]: https://github.com/dfns/cggmp21/pull/101
 
 ## v0.2.1
 * Bump key-share to `^0.2.3` [#99]

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 cggmp21-keygen = { path = "../cggmp21-keygen", version = "0.2" }
-key-share = { path = "../key-share", version = "0.2.2", features = ["serde"] }
+key-share = { path = "../key-share", version = "0.3", features = ["serde"] }
 
 generic-ec = { version = "0.3", features = ["serde", "udigest"] }
 generic-ec-zkp = { version = "0.3", features = ["serde", "udigest"] }

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -15,11 +15,11 @@ readme = "../README.md"
 cggmp21-keygen = { path = "../cggmp21-keygen", version = "0.2" }
 key-share = { path = "../key-share", version = "0.2.2", features = ["serde"] }
 
-generic-ec = { version = "0.2", features = ["serde", "udigest"] }
-generic-ec-zkp = { version = "0.2", features = ["serde", "udigest"] }
+generic-ec = { version = "0.3", features = ["serde", "udigest"] }
+generic-ec-zkp = { version = "0.3", features = ["serde", "udigest"] }
 round-based = { version = "0.3", features = ["derive"] }
 
-paillier-zk = { version = "0.2", features = ["serde"] }
+paillier-zk = { version = "0.3", features = ["serde"] }
 udigest = { version = "0.1", features = ["std", "derive"]}
 
 digest = "0.10"

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_with = { version = "2" }
 hex = { version = "0.4", default-features = false, features = ["serde"] }
 
-slip-10 = { version = "0.2", optional = true, features = ["std"] }
+slip-10 = { version = "0.3", optional = true, features = ["std"] }
 
 [dev-dependencies]
 round-based = { version = "0.3", features = ["derive", "dev"] }

--- a/cggmp21/src/signing.rs
+++ b/cggmp21/src/signing.rs
@@ -3,7 +3,7 @@
 use digest::Digest;
 use futures::SinkExt;
 use generic_ec::{coords::AlwaysHasAffineX, Curve, NonZero, Point, Scalar, SecretScalar};
-use generic_ec_zkp::polynomial::lagrange_coefficient;
+use generic_ec_zkp::polynomial::lagrange_coefficient_at_zero;
 use paillier_zk::rug::Complete;
 use paillier_zk::{fast_paillier, rug::Integer};
 use paillier_zk::{
@@ -494,11 +494,10 @@ where
         let I = utils::subset(S, I).ok_or(Bug::Subset)?;
         let X = utils::subset(S, &key_share.core.public_shares).ok_or(Bug::Subset)?;
 
-        let lambda_i =
-            lagrange_coefficient(Scalar::zero(), usize::from(i), &I).ok_or(Bug::LagrangeCoef)?;
+        let lambda_i = lagrange_coefficient_at_zero(usize::from(i), &I).ok_or(Bug::LagrangeCoef)?;
         let x_i = (lambda_i * &key_share.core.x).into_secret();
 
-        let lambda = (0..t).map(|j| lagrange_coefficient(Scalar::zero(), usize::from(j), &I));
+        let lambda = (0..t).map(|j| lagrange_coefficient_at_zero(usize::from(j), &I));
         let X = lambda
             .zip(&X)
             .map(|(lambda_j, X_j)| Some(lambda_j? * X_j))

--- a/key-share/CHANGELOG.md
+++ b/key-share/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.0
+* Update `generic-ec` and `slip-10` deps to latest version [#101]
+* Optimize key share verification using new features of `generic-ec` [#101]
+
+[#101]: https://github.com/dfns/cggmp21/pull/101
+
 ## v0.2.3
 * Reduce size of serialized key share [#96]
 

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -15,7 +15,7 @@ generic-ec = { version = "0.3", default-features = false, features = ["alloc"] }
 generic-ec-zkp = { version = "0.3", default-features = false, features = ["alloc"] }
 rand_core = { version = "0.6", optional = true }
 
-slip-10 = { version = "0.2", optional = true }
+slip-10 = { version = "0.3", optional = true }
 udigest = { version = "0.1", default-features = false, features = ["alloc", "derive"], optional = true }
 
 serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["mpc", "threshold-signatures", "tss"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = { version = "0.2.3", default-features = false, features = ["alloc"] }
-generic-ec-zkp = { version = "0.2", default-features = false, features = ["alloc"] }
+generic-ec = { version = "0.3", default-features = false, features = ["alloc"] }
+generic-ec-zkp = { version = "0.3", default-features = false, features = ["alloc"] }
 rand_core = { version = "0.6", optional = true }
 
 slip-10 = { version = "0.2", optional = true }

--- a/key-share/Cargo.toml
+++ b/key-share/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key-share"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Key share of any Threshold Signature Scheme (TSS)"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,7 +25,7 @@ rand_chacha = "0.3"
 sha2 = "0.10"
 
 round-based = { version = "0.3", features = ["derive", "dev", "state-machine"] }
-generic-ec = { version = "0.2", features = ["serde", "all-curves"] }
+generic-ec = { version = "0.3", features = ["serde", "all-curves"] }
 
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"


### PR DESCRIPTION
* Update deps (generic-ec, paillier-zk, slip-10) to latest
* Optimize key share verification and signing using new things from generic-ec