### PR TITLE
Batch p2p messages in one round instead of flushing immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "hex",
  "include_dir",
  "lazy_static",
+ "pin-project",
  "rand",
  "rand_dev",
  "round-based",
@@ -1717,6 +1718,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e68f5dc797c2a743e024e1c53215474598faf0408826a90249569ad7f47adeaa"
 dependencies = [
  "educe",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ version = "0.5.0"
 dependencies = [
  "digest",
  "displaydoc",
+ "futures",
  "generic-ec",
  "generic-ec-zkp",
  "hd-wallet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ version = "0.5.0"
 dependencies = [
  "digest",
  "displaydoc",
- "futures",
+ "futures-util",
  "generic-ec",
  "generic-ec-zkp",
  "hd-wallet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "round-based"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079e623c882b5ec9c1a4140cb077179ea89f5352f85a7ebd879428c33ce66399"
+checksum = "da76edf50de0a9d6911fc79261bb04cc9f3f3a375e0201799f5edf58499af341"
 dependencies = [
  "futures-util",
  "phantom-type 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ key-share = { version = "0.6", path = "key-share", default-features = false }
 
 generic-ec = { version = "0.4.1", default-features = false } 
 generic-ec-zkp = { version = "0.4.1", default-features = false } 
-round-based = { version = "0.4", default-features = false }
+round-based = { version = "0.4.1", default-features = false }
 
 paillier-zk = "0.4.1" 
 udigest = { version = "0.2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand_core = { version = "0.6", default-features = false }
 rand_hash = { version = "0.1" }
 rand_dev = "0.1"
 
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 
 anyhow = "1"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand_hash = { version = "0.1" }
 rand_dev = "0.1"
 
 futures = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 
 anyhow = "1"
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Our implementation has been audited by Kudelski. Report can be found [here][repo
 
 > About notion of threshold and non-threshold keys: originally, CGGMP21 paper does not have support of
 arbitrary `t` and only works with non-threshold n-out-of-n keys. We have added support of arbitrary
-threshold $2 \le t \le n$, however, we made it possible to opt out therhsoldness so original CGGMP21
+threshold $2 \le t \le n$, however, we made it possible to opt out thresholdness so original CGGMP21
 protocol can be carried out if needed.
 
 ## Running the protocol
@@ -70,7 +70,7 @@ let outgoing: impl Sink<Outgoing<Msg>>;
 
 where:
 * `Msg` is a protocol message (e.g., `signing::msg::Msg`)
-* `round_based::Incoming` and `round_based::Outgoing` wrap `Msg` and provide additional data (e.g., sender/recepient)
+* `round_based::Incoming` and `round_based::Outgoing` wrap `Msg` and provide additional data (e.g., sender/recipient)
 * `futures::Stream` and `futures::Sink` are well-known async primitives.
 
 Once you have that, you can construct an `MpcParty`:
@@ -256,7 +256,7 @@ they are all documented in [the spec].
 ## Timing attacks
 Timing attacks are type of side-channel attacks that leak sensitive information through duration of
 execution. We consider timing attacks out of scope as they are nearly impossible to perform for such
-complicated protcol as CGGMP21 and impossible to do in our specific deployment. Thus, we intentionally
+complicated protocol as CGGMP21 and impossible to do in our specific deployment. Thus, we intentionally
 don't do constant-time operations which gives us a significant performance boost.
 
 ## Join us in Discord!

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 
-futures = { workspace = true }
+futures-util = { workspace = true }
 
 displaydoc = { workspace = true }
 thiserror = { workspace = true, optional = true }

--- a/cggmp21-keygen/Cargo.toml
+++ b/cggmp21-keygen/Cargo.toml
@@ -28,6 +28,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 
+futures = { workspace = true }
+
 displaydoc = { workspace = true }
 thiserror = { workspace = true, optional = true }
 

--- a/cggmp21-keygen/src/threshold.rs
+++ b/cggmp21-keygen/src/threshold.rs
@@ -277,15 +277,16 @@ where
         .await
         .map_err(IoError::send_message)?;
 
-    for j in utils::iter_peers(i, n) {
+    let messages = utils::iter_peers(i, n).map(|j| {
         let message = MsgRound2Uni {
             sigma: sigmas[usize::from(j)],
         };
-        outgoings
-            .send(Outgoing::p2p(j, Msg::Round2Uni(message)))
-            .await
-            .map_err(IoError::send_message)?;
-    }
+        Outgoing::p2p(j, Msg::Round2Uni(message))
+    });
+    outgoings
+        .send_all(&mut futures::stream::iter(messages.map(Ok)))
+        .await
+        .map_err(IoError::send_message)?;
     tracer.msg_sent();
 
     // Round 3

--- a/cggmp21-keygen/src/threshold.rs
+++ b/cggmp21-keygen/src/threshold.rs
@@ -284,7 +284,7 @@ where
         Outgoing::p2p(j, Msg::Round2Uni(message))
     });
     outgoings
-        .send_all(&mut futures::stream::iter(messages.map(Ok)))
+        .send_all(&mut futures_util::stream::iter(messages.map(Ok)))
         .await
         .map_err(IoError::send_message)?;
     tracer.msg_sent();

--- a/cggmp21-keygen/src/threshold.rs
+++ b/cggmp21-keygen/src/threshold.rs
@@ -271,7 +271,7 @@ where
 
     tracer.send_msg();
     outgoings
-        .send(Outgoing::broadcast(Msg::Round2Broad(
+        .feed(Outgoing::broadcast(Msg::Round2Broad(
             my_decommitment.clone(),
         )))
         .await

--- a/cggmp21/src/key_refresh/aux_only.rs
+++ b/cggmp21/src/key_refresh/aux_only.rs
@@ -418,11 +418,15 @@ where
             fac_proof: phi.clone(),
         };
         outgoings
-            .send(Outgoing::p2p(j, Msg::Round3(msg)))
+            .feed(Outgoing::p2p(j, Msg::Round3(msg)))
             .await
             .map_err(IoError::send_message)?;
         tracer.msg_sent();
     }
+
+    tracer.send_msg();
+    outgoings.flush().await.map_err(IoError::send_message)?;
+    tracer.msg_sent();
 
     // Output
     tracer.round_begins();

--- a/cggmp21/src/key_refresh/non_threshold.rs
+++ b/cggmp21/src/key_refresh/non_threshold.rs
@@ -523,11 +523,15 @@ where
             C,
         };
         outgoings
-            .send(Outgoing::p2p(j, Msg::Round3(msg)))
+            .feed(Outgoing::p2p(j, Msg::Round3(msg)))
             .await
             .map_err(IoError::send_message)?;
         tracer.msg_sent();
     }
+
+    tracer.send_msg();
+    outgoings.flush().await.map_err(IoError::send_message)?;
+    tracer.msg_sent();
 
     // Output
     tracer.round_begins();

--- a/cggmp21/src/lib.rs
+++ b/cggmp21/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! > About notion of threshold and non-threshold keys: originally, CGGMP21 paper does not have support of
 //! arbitrary `t` and only works with non-threshold n-out-of-n keys. We have added support of arbitrary
-//! threshold $2 \le t \le n$, however, we made it possible to opt out therhsoldness so original CGGMP21
+//! threshold $2 \le t \le n$, however, we made it possible to opt out thresholdness so original CGGMP21
 //! protocol can be carried out if needed.
 //!
 //! ## Running the protocol
@@ -52,7 +52,7 @@
 //!
 //! where:
 //! * `Msg` is a protocol message (e.g., [`signing::msg::Msg`])
-//! * [`round_based::Incoming`] and [`round_based::Outgoing`] wrap `Msg` and provide additional data (e.g., sender/recepient)
+//! * [`round_based::Incoming`] and [`round_based::Outgoing`] wrap `Msg` and provide additional data (e.g., sender/recipient)
 //! * [`futures::Stream`] and [`futures::Sink`] are well-known async primitives.
 //!
 //! Once you have that, you can construct an [`MpcParty`](round_based::MpcParty):
@@ -281,7 +281,7 @@
 //! ## Timing attacks
 //! Timing attacks are type of side-channel attacks that leak sensitive information through duration of
 //! execution. We consider timing attacks out of scope as they are nearly impossible to perform for such
-//! complicated protcol as CGGMP21 and impossible to do in our specific deployment. Thus, we intentionally
+//! complicated protocol as CGGMP21 and impossible to do in our specific deployment. Thus, we intentionally
 //! don't do constant-time operations which gives us a significant performance boost.
 //!
 //! ## Join us in Discord!

--- a/cggmp21/src/signing.rs
+++ b/cggmp21/src/signing.rs
@@ -715,13 +715,12 @@ where
         )
         .map_err(|e| Bug::PiEnc(BugSource::psi0, e))?;
 
-        tracer.send_msg();
         outgoings
-            .send(Outgoing::p2p(j, Msg::Round1b(MsgRound1b { psi0 })))
+            .feed(Outgoing::p2p(j, Msg::Round1b(MsgRound1b { psi0 })))
             .await
             .map_err(IoError::send_message)?;
-        tracer.msg_sent();
     }
+    outgoings.flush().await.map_err(IoError::send_message)?;
 
     // Round 2
     tracer.round_begins();
@@ -950,9 +949,8 @@ where
         .map_err(|e| Bug::PiLog(BugSource::psi_prime, e))?;
         runtime.yield_now().await;
 
-        tracer.send_msg();
         outgoings
-            .send(Outgoing::p2p(
+            .feed(Outgoing::p2p(
                 j,
                 Msg::Round2(MsgRound2 {
                     Gamma: Gamma_i,
@@ -967,8 +965,8 @@ where
             ))
             .await
             .map_err(IoError::send_message)?;
-        tracer.msg_sent();
     }
+    outgoings.flush().await.map_err(IoError::send_message)?;
 
     // Round 3
     tracer.round_begins();
@@ -1124,9 +1122,8 @@ where
         )
         .map_err(|e| Bug::PiLog(BugSource::psi_prime_prime, e))?;
 
-        tracer.send_msg();
         outgoings
-            .send(Outgoing::p2p(
+            .feed(Outgoing::p2p(
                 j,
                 Msg::Round3(MsgRound3 {
                     delta: delta_i,
@@ -1136,8 +1133,8 @@ where
             ))
             .await
             .map_err(IoError::send_message)?;
-        tracer.msg_sent();
     }
+    outgoings.flush().await.map_err(IoError::send_message)?;
 
     // Output
     tracer.named_round_begins("Presig output");

--- a/cggmp21/src/signing.rs
+++ b/cggmp21/src/signing.rs
@@ -687,7 +687,7 @@ where
 
     tracer.send_msg();
     outgoings
-        .send(Outgoing::broadcast(Msg::Round1a(MsgRound1a {
+        .feed(Outgoing::broadcast(Msg::Round1a(MsgRound1a {
             K: K_i.clone(),
             G: G_i.clone(),
         })))

--- a/cggmp21/src/signing.rs
+++ b/cggmp21/src/signing.rs
@@ -715,12 +715,16 @@ where
         )
         .map_err(|e| Bug::PiEnc(BugSource::psi0, e))?;
 
+        tracer.send_msg();
         outgoings
             .feed(Outgoing::p2p(j, Msg::Round1b(MsgRound1b { psi0 })))
             .await
             .map_err(IoError::send_message)?;
+        tracer.msg_sent();
     }
+    tracer.send_msg();
     outgoings.flush().await.map_err(IoError::send_message)?;
+    tracer.msg_sent();
 
     // Round 2
     tracer.round_begins();
@@ -949,6 +953,7 @@ where
         .map_err(|e| Bug::PiLog(BugSource::psi_prime, e))?;
         runtime.yield_now().await;
 
+        tracer.send_msg();
         outgoings
             .feed(Outgoing::p2p(
                 j,
@@ -965,8 +970,11 @@ where
             ))
             .await
             .map_err(IoError::send_message)?;
+        tracer.msg_sent();
     }
+    tracer.send_msg();
     outgoings.flush().await.map_err(IoError::send_message)?;
+    tracer.msg_sent();
 
     // Round 3
     tracer.round_begins();
@@ -1122,6 +1130,7 @@ where
         )
         .map_err(|e| Bug::PiLog(BugSource::psi_prime_prime, e))?;
 
+        tracer.send_msg();
         outgoings
             .feed(Outgoing::p2p(
                 j,
@@ -1133,8 +1142,11 @@ where
             ))
             .await
             .map_err(IoError::send_message)?;
+        tracer.msg_sent();
     }
+    tracer.send_msg();
     outgoings.flush().await.map_err(IoError::send_message)?;
+    tracer.msg_sent();
 
     // Output
     tracer.named_round_begins("Presig output");

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,7 @@ include_dir = "0.7"
 ciborium = "0.2"
 
 futures = "0.3"
+pin-project = "1"
 
 lazy_static = "1.4"
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -60,9 +60,14 @@ impl<M: Unpin, Inner: futures::Sink<M>> futures::Sink<M> for BufferedSink<M, Inn
     }
 }
 
-/// Map a party to add explicit buffering to outgoing messages in case the
-/// underlying sink doesn't do buffering. This is useful to test that we don't
-/// forget to flush the sinks in our protocol implementations.
+/// Modified 'Delivery' of the party to buffer outgoing messages. The messages
+/// fed to the 'Delivery' sink will be buffered indefinitely until `flush` is
+/// called
+///
+/// This is useful since the delivery used in round-based simulation doesn't do
+/// buffering at all, however we want to verify that we don't forget to flush
+/// the messages in our protocols. When this function is used, forgetting to
+/// flush will cause the test to get stuck.
 pub fn buffer_outgoing<M, D, R>(
     party: round_based::MpcParty<M, D, R>,
 ) -> round_based::MpcParty<M, BufferedDelivery<M, D>, R>

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,6 +4,81 @@ use generic_ec::Curve;
 use rand::RngCore;
 use serde_json::{Map, Value};
 
+#[pin_project::pin_project]
+pub struct BufferedSink<M, Inner> {
+    #[pin]
+    messages: Vec<M>,
+    #[pin]
+    inner: Inner,
+}
+type BufferedDelivery<M, D> = (
+    <D as round_based::Delivery<M>>::Receive,
+    BufferedSink<round_based::Outgoing<M>, <D as round_based::Delivery<M>>::Send>,
+);
+
+impl<M: Unpin, Inner: futures::Sink<M>> futures::Sink<M> for BufferedSink<M, Inner> {
+    type Error = Inner::Error;
+
+    fn poll_ready(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: std::pin::Pin<&mut Self>, item: M) -> Result<(), Self::Error> {
+        self.project().messages.get_mut().push(item);
+        Ok(())
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        while !self.messages.is_empty() {
+            let mut projection = self.as_mut().project();
+            let mut inner = projection.inner;
+            match inner.as_mut().poll_ready(cx) {
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+                std::task::Poll::Ready(Ok(())) => {
+                    if let Some(item) = projection.messages.pop() {
+                        inner.as_mut().start_send(item)?;
+                    }
+                }
+                err => return err,
+            }
+        }
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+pub fn buffer_outgoing<M, D, R>(
+    party: round_based::MpcParty<M, D, R>,
+) -> round_based::MpcParty<M, BufferedDelivery<M, D>, R>
+where
+    M: Unpin,
+    D: round_based::Delivery<M>,
+    R: round_based::runtime::AsyncRuntime,
+{
+    let round_based::MpcParty {
+        delivery, runtime, ..
+    } = party;
+    let (incoming, outgoing) = delivery.split();
+    let buffered_outgoing = BufferedSink::<round_based::Outgoing<M>, D::Send> {
+        messages: Vec::new(),
+        inner: outgoing,
+    };
+    let buffered_delivery = (incoming, buffered_outgoing);
+    round_based::MpcParty::connected(buffered_delivery).set_runtime(runtime)
+}
+
 pub mod external_verifier;
 
 lazy_static::lazy_static! {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,10 +4,11 @@ use generic_ec::Curve;
 use rand::RngCore;
 use serde_json::{Map, Value};
 
+/// Wraps a sink to buffer the messages. Used in [`buffer_outgoing`]
 #[pin_project::pin_project]
 pub struct BufferedSink<M, Inner> {
     #[pin]
-    messages: Vec<M>,
+    messages: std::collections::VecDeque<M>,
     #[pin]
     inner: Inner,
 }
@@ -23,11 +24,12 @@ impl<M: Unpin, Inner: futures::Sink<M>> futures::Sink<M> for BufferedSink<M, Inn
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
+        // Always ready to buffer
         std::task::Poll::Ready(Ok(()))
     }
 
     fn start_send(self: std::pin::Pin<&mut Self>, item: M) -> Result<(), Self::Error> {
-        self.project().messages.get_mut().push(item);
+        self.project().messages.get_mut().push_back(item);
         Ok(())
     }
 
@@ -35,17 +37,16 @@ impl<M: Unpin, Inner: futures::Sink<M>> futures::Sink<M> for BufferedSink<M, Inn
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
+        // Feed all buffered messages one by one
         while !self.messages.is_empty() {
             let mut projection = self.as_mut().project();
             let mut inner = projection.inner;
-            match inner.as_mut().poll_ready(cx) {
-                std::task::Poll::Pending => return std::task::Poll::Pending,
-                std::task::Poll::Ready(Ok(())) => {
-                    if let Some(item) = projection.messages.pop() {
-                        inner.as_mut().start_send(item)?;
-                    }
-                }
-                err => return err,
+            // In case the inner sink wasn't ready, this method will be retried.
+            // We rely on this and don't modify any internal state before this
+            // point
+            std::task::ready!(inner.as_mut().poll_ready(cx))?;
+            if let Some(item) = projection.messages.pop_front() {
+                inner.as_mut().start_send(item)?;
             }
         }
         self.project().inner.poll_flush(cx)
@@ -59,6 +60,9 @@ impl<M: Unpin, Inner: futures::Sink<M>> futures::Sink<M> for BufferedSink<M, Inn
     }
 }
 
+/// Map a party to add explicit buffering to outgoing messages in case the
+/// underlying sink doesn't do buffering. This is useful to test that we don't
+/// forget to flush the sinks in our protocol implementations.
 pub fn buffer_outgoing<M, D, R>(
     party: round_based::MpcParty<M, D, R>,
 ) -> round_based::MpcParty<M, BufferedDelivery<M, D>, R>
@@ -72,7 +76,7 @@ where
     } = party;
     let (incoming, outgoing) = delivery.split();
     let buffered_outgoing = BufferedSink::<round_based::Outgoing<M>, D::Send> {
-        messages: Vec::new(),
+        messages: std::collections::VecDeque::new(),
         inner: outgoing,
     };
     let buffered_delivery = (incoming, buffered_outgoing);

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -71,16 +71,14 @@ where
     D: round_based::Delivery<M>,
     R: round_based::runtime::AsyncRuntime,
 {
-    let round_based::MpcParty {
-        delivery, runtime, ..
-    } = party;
-    let (incoming, outgoing) = delivery.split();
-    let buffered_outgoing = BufferedSink::<round_based::Outgoing<M>, D::Send> {
-        messages: std::collections::VecDeque::new(),
-        inner: outgoing,
-    };
-    let buffered_delivery = (incoming, buffered_outgoing);
-    round_based::MpcParty::connected(buffered_delivery).set_runtime(runtime)
+    party.map_delivery(|delivery| {
+        let (incoming, outgoing) = delivery.split();
+        let buffered_outgoing = BufferedSink::<round_based::Outgoing<M>, D::Send> {
+            messages: std::collections::VecDeque::new(),
+            inner: outgoing,
+        };
+        (incoming, buffered_outgoing)
+    })
 }
 
 pub mod external_verifier;

--- a/tests/tests/it/key_refresh.rs
+++ b/tests/tests/it/key_refresh.rs
@@ -39,6 +39,7 @@ where
     let eid = ExecutionId::new(&eid);
 
     let key_shares = round_based::sim::run_with_setup(&shares, |_i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
         let pregenerated_data = primes.next().expect("Can't fetch primes");
         async move {
@@ -94,6 +95,7 @@ where
     let message_to_sign = cggmp21::signing::DataToSign::digest::<Sha256>(&[42; 100]);
     let participants = &(0..n).collect::<Vec<_>>();
     let sig = round_based::sim::run_with_setup(&key_shares, |_i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
         async move {
             cggmp21::signing(eid, share.core.i, participants, share)
@@ -136,6 +138,7 @@ where
     let eid = ExecutionId::new(&eid);
 
     let aux_infos = round_based::sim::run(n, |i, party| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
         let pregenerated_data = primes.next().expect("Can't fetch primes");
         async move {
@@ -179,6 +182,7 @@ where
     let participants_shares = participants.iter().map(|i| &key_shares[usize::from(*i)]);
 
     let sig = round_based::sim::run_with_setup(participants_shares, |i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
         async move {
             cggmp21::signing(eid, i, participants, share)

--- a/tests/tests/it/keygen.rs
+++ b/tests/tests/it/keygen.rs
@@ -35,6 +35,7 @@ fn keygen_works<E: Curve>(n: u16, reliable_broadcast: bool, hd_wallet: bool) {
     let eid = ExecutionId::new(&eid);
 
     let key_shares = round_based::sim::run(n, |i, party| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         async move {
@@ -77,6 +78,7 @@ fn threshold_keygen_works<E: Curve>(t: u16, n: u16, reliable_broadcast: bool, hd
     let eid = ExecutionId::new(&eid);
 
     let key_shares = round_based::sim::run(n, |i, party| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         async move {

--- a/tests/tests/it/pipeline.rs
+++ b/tests/tests/it/pipeline.rs
@@ -40,6 +40,7 @@ where
     let eid = ExecutionId::new(&eid);
 
     round_based::sim::run(n, |i, party| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         async move {
@@ -67,6 +68,7 @@ where
     let eid = ExecutionId::new(&eid);
 
     let aux_infos = round_based::sim::run(n, |i, party| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
         let pregenerated_data = primes.next().expect("Can't fetch primes");
         async move {
@@ -121,6 +123,7 @@ where
     let participants_shares = participants.iter().map(|i| &shares[usize::from(*i)]);
 
     let sig = round_based::sim::run_with_setup(participants_shares, |i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         #[cfg(feature = "hd-wallet")]

--- a/tests/tests/it/signing.rs
+++ b/tests/tests/it/signing.rs
@@ -68,6 +68,7 @@ where
     let participants_shares = participants.iter().map(|i| &shares[usize::from(*i)]);
 
     let sig = round_based::sim::run_with_setup(participants_shares, |i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         let signing = cggmp21::signing(eid, i, participants, share)
@@ -147,6 +148,7 @@ where
     let participants_shares = participants.iter().map(|i| &shares[usize::from(*i)]);
 
     let presigs = round_based::sim::run_with_setup(participants_shares, |i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         async move {

--- a/tests/tests/it/stark_prehashed.rs
+++ b/tests/tests/it/stark_prehashed.rs
@@ -71,6 +71,7 @@ fn sign_transaction() {
     let participants_shares = participants.iter().map(|i| &shares[usize::from(*i)]);
 
     let sig = round_based::sim::run_with_setup(participants_shares, |i, party, share| {
+        let party = cggmp21_tests::buffer_outgoing(party);
         let mut party_rng = rng.fork();
 
         async move {

--- a/wasm/no_std/Cargo.lock
+++ b/wasm/no_std/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.5.0"
 dependencies = [
  "digest",
  "displaydoc",
+ "futures",
  "generic-ec",
  "generic-ec-zkp",
  "hd-wallet",
@@ -214,10 +215,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"


### PR DESCRIPTION
I removed p2p message tracing from signing because I couldn't make sense of it. Ideas of how to track it are welcome