### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -19,11 +19,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: base_branch
         ref: ${{ github.base_ref }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: pr_branch
     - name: Retrieve base branch deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v3
       with:
@@ -40,7 +40,7 @@ jobs:
   build_docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref_name, 'v')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: cargo publish -p cggmp21
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
@@ -34,10 +34,10 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref_name, 'key-share-v')
     steps:
-    - uses: actions/checkout@v3
-    - run: cargo publish -p key-share --token ${CRATES_TOKEN}
+    - uses: actions/checkout@v4
+    - run: cargo publish -p key-share
       env:
-        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
   publish-cggmp21-keygen:
     name: Publish cggmp21-keygen
@@ -47,7 +47,7 @@ jobs:
       github.ref_type == 'tag'
       && startsWith(github.ref_name, 'cggmp21-keygen-v')
     steps:
-    - uses: actions/checkout@v3
-    - run: cargo publish -p cggmp21-keygen --token ${CRATES_TOKEN}
+    - uses: actions/checkout@v4
+    - run: cargo publish -p cggmp21-keygen
       env:
-        CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -12,7 +12,7 @@ jobs:
   check_readme:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install cargo-hakari
       uses: baptiste0928/cargo-install@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
     - name: Build
       run: cargo build --release --all-features
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: benchmark-tool
         path: target/release/measure_perf
@@ -35,7 +35,7 @@ jobs:
         - cggmp21-keygen
         - cggmp21
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -44,7 +44,7 @@ jobs:
   build-wasm-nostd:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -58,7 +58,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -68,7 +68,7 @@ jobs:
   test-hd:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -78,13 +78,13 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check formatting
       run: cargo fmt --all -- --check
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: dtolnay/rust-toolchain@nightly
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
@@ -111,8 +111,8 @@ jobs:
       pull-requests: write
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with:
         name: benchmark-tool
     - name: Set file permissions
@@ -129,6 +129,6 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check changelogs
       run: ./.github/changelog.sh


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/