### PR TITLE
fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let outgoing: impl Sink<Outgoing<Msg>>;
 
 where:
 * `Msg` is a protocol message (e.g., `signing::msg::Msg`)
-* `round_based::Incoming` and `round_based::Outgoing` wrap `Msg` and provide additional data (e.g., sender/recepient)
+* `round_based::Incoming` and `round_based::Outgoing` wrap `Msg` and provide additional data (e.g., sender/recipient)
 * `futures::Stream` and `futures::Sink` are well-known async primitives.
 
 Once you have that, you can construct an `MpcParty`:


### PR DESCRIPTION
# fix: typo in README.md

## Description
This pull request fixes a minor typo in the `README.md` file:

- Corrected "recepient" to "recipient" for accuracy and consistency.


