### PR TITLE
feat: implementation of paillier encryption in range with El-Gamal commitment

### DIFF
--- a/paillier-zk/src/lib.rs
+++ b/paillier-zk/src/lib.rs
@@ -14,6 +14,7 @@ pub mod no_small_factor;
 pub mod paillier_affine_operation_in_range;
 pub mod paillier_blum_modulus;
 pub mod paillier_encryption_in_range;
+pub mod paillier_encryption_in_range_with_el_gamal;
 
 #[cfg(test)]
 mod curve;

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -1,0 +1,504 @@
+//! ZK-proof of paillier encryption in range with El-Gamal commitment.
+//! Called Пenc-elg or Renc-elg in the CGGMP24
+//! paper.
+//!
+//! ## Description
+//!
+//! A party P has `key` - public key in paillier
+//! cryptosystem. P also has `plaintext`, `nonce`,`a`,`b` and
+//! `ciphertext = key.encrypt_with(plaintext, nonce)`,
+//! `g_to_a = Point::<E>::generator() * a.to_scalar()`,
+//! `g_to_b = Point::<E>::generator() * b.to_scalar()`
+//! `g_to_ab_plus_x = Point::<E>::generator() * ((&a * &b + &plaintext).complete()).to_scalar()`
+//!
+//! P wants to prove that `plaintext` is at most `l` bits, without disclosing
+//! it, the `nonce`,`a`, and `b`
+
+//! ## Example
+//!
+//! ```
+//! use paillier_zk::{paillier_encryption_in_range_with_el_gamal as p, IntegerExt};
+//! use rug::{Integer, Complete};
+//! use generic_ec::{Point, curves::Secp256k1 as E};
+//! # mod pregenerated {
+//! #     use super::*;
+//! #     paillier_zk::load_pregenerated_data!(
+//! #         verifier_aux: p::Aux,
+//! #         prover_decryption_key: fast_paillier::DecryptionKey,
+//! #     );
+//! # }
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!
+//! let shared_state = "some shared state";
+//!
+//! let mut rng = rand_core::OsRng;
+//! # let mut rng = rand_dev::DevRng::new();
+//!
+//! // 0. Setup: prover and verifier share common Ring-Pedersen parameters:
+//!
+//! let aux: p::Aux = pregenerated::verifier_aux();
+//! let security = p::SecurityParams {
+//!     l: 1024,
+//!     epsilon: 128,
+//!     q: (Integer::ONE << 128_u32).into(),
+//! };
+//!
+//! // 1. Setup: prover prepares the paillier keys
+//!
+//! let private_key: fast_paillier::DecryptionKey =
+//!     pregenerated::prover_decryption_key();
+//! let key = private_key.encryption_key();
+//!
+//! // 2. Setup: prover has some plaintext and encrypts it
+//!
+//! let plaintext = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
+//! let (ciphertext, nonce) = key.encrypt_with_random(&mut rng, &plaintext)?;
+//!
+//! let a = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
+//! let b = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
+//!
+//! let g_to_a = Point::<E>::generator() * a.to_scalar();
+//! let g_to_b = Point::<E>::generator() * b.to_scalar();
+//! let exponent = (&a * &b + &plaintext).complete();
+//! let g_to_ab_plus_x = Point::<E>::generator() * exponent.to_scalar();
+//!
+//! // 3. Prover computes a non-interactive proof that plaintext is at most 1024 bits:
+//!
+//! let data = p::Data { key, ciphertext: &ciphertext , g_to_a: &g_to_a,
+//!     g_to_b: &g_to_b ,g_to_ab_plus_x: &g_to_ab_plus_x};
+//! let (commitment, proof) = p::non_interactive::prove::<E,sha2::Sha256>(
+//!     &shared_state,
+//!     &aux,
+//!     data,
+//!     p::PrivateData {
+//!         plaintext: &plaintext,
+//!         nonce: &nonce,
+//!         a: &a,
+//!         b:&b
+//!     },
+//!     &security,
+//!     &mut rng,
+//! )?;
+//!
+//! // 4. Prover sends this data to verifier
+//!
+//! # use generic_ec::Curve;
+//! # fn send<E: Curve>(_: &p::Data<E>, _: &p::Commitment<E>, _: &p::Proof) {  }
+//! send(&data, &commitment, &proof);
+//!
+//! // 5. Verifier receives the data and the proof and verifies it
+//!
+//! # let recv = || (data, commitment, proof);
+//! let (data, commitment, proof) = recv();
+//! p::non_interactive::verify::<E, sha2::Sha256>(
+//!     &shared_state,
+//!     &aux,
+//!     data,
+//!     &commitment,
+//!     &security,
+//!     &proof,
+//! );
+//! # Ok(()) }
+//! ```
+//!
+//! If the verification succeeded, verifier can continue communication with prover
+
+use fast_paillier::{AnyEncryptionKey, Ciphertext, Nonce};
+use generic_ec::{Curve, Point};
+use rug::Integer;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+pub use crate::common::Aux;
+pub use crate::common::InvalidProof;
+
+/// Security parameters for proof. Choosing the values is a tradeoff between
+/// speed and chance of rejecting a valid proof or accepting an invalid proof
+#[derive(Debug, Clone, udigest::Digestable)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SecurityParams {
+    /// l in paper, security parameter for bit size of plaintext: it needs to
+    /// be in range [-2^l; 2^l] or equivalently 2^l
+    pub l: usize,
+    /// Epsilon in paper, slackness parameter
+    pub epsilon: usize,
+    /// q in paper. Security parameter for challenge
+    #[udigest(as = crate::common::encoding::Integer)]
+    pub q: Integer,
+}
+
+/// Public data that both parties know
+#[derive(Debug, Clone, Copy, udigest::Digestable)]
+#[udigest(bound = "")]
+pub struct Data<'a, C: Curve> {
+    /// N0 in paper, public key that x -> C was encrypted on
+    #[udigest(as = crate::common::encoding::AnyEncryptionKey)]
+    pub key: &'a dyn AnyEncryptionKey,
+    /// C in paper
+    #[udigest(as = &crate::common::encoding::Integer)]
+    pub ciphertext: &'a Ciphertext,
+    /// A=g^a in paper
+    pub g_to_a: &'a Point<C>,
+    /// B=g^b in paper
+    pub g_to_b: &'a Point<C>,
+    /// X=g^{ab+x} in paper
+    pub g_to_ab_plus_x: &'a Point<C>,
+}
+
+/// Private data of prover
+#[derive(Clone, Copy)]
+pub struct PrivateData<'a> {
+    /// x in paper, plaintext of C
+    pub plaintext: &'a Integer,
+    /// rho in paper, nonce of encryption x -> C
+    pub nonce: &'a Nonce,
+    /// a in paper, preimage of A
+    pub a: &'a Integer,
+    /// b in paper, preimage of B
+    pub b: &'a Integer,
+}
+
+// As described in cggmp24 at page 58
+/// Prover's first message, obtained by [`interactive::commit`]
+#[derive(Debug, Clone, udigest::Digestable)]
+#[udigest(bound = "")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Commitment<C: Curve> {
+    #[udigest(as = crate::common::encoding::Integer)]
+    pub s: Integer,
+    #[udigest(as = crate::common::encoding::Integer)]
+    pub t: Integer,
+    #[udigest(as = crate::common::encoding::Integer)]
+    pub d: Integer,
+    pub y: Point<C>,
+    pub z: Point<C>,
+}
+
+/// Prover's data accompanying the commitment. Kept as state between rounds in
+/// the interactive protocol.
+#[derive(Clone)]
+pub struct PrivateCommitment {
+    pub alpha: Integer,
+    pub mu: Integer,
+    pub r: Integer,
+    pub beta: Integer,
+    pub gamma: Integer,
+}
+
+/// Verifier's challenge to prover. Can be obtained deterministically by
+/// [`non_interactive::challenge`] or randomly by [`interactive::challenge`]
+pub type Challenge = Integer;
+
+// As described in cggmp24 at page 58
+/// The ZK proof. Computed by [`interactive::prove`] or
+/// [`non_interactive::prove`]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Proof {
+    pub z1: Integer,
+    pub z2: Integer,
+    pub z3: Integer,
+    pub w: Integer,
+}
+
+/// The interactive version of the ZK proof. Should be completed in 3 rounds:
+/// prover commits to data, verifier responds with a random challenge, and
+/// prover gives proof with commitment and challenge.
+pub mod interactive {
+    use generic_ec::{Curve, Point};
+    use rand_core::RngCore;
+    use rug::{Complete, Integer};
+
+    use crate::{
+        common::{fail_if, fail_if_ne, InvalidProofReason},
+        BadExponent, Error,
+    };
+
+    use crate::common::{IntegerExt, InvalidProof};
+
+    use super::{
+        Aux, Challenge, Commitment, Data, PrivateCommitment, PrivateData, Proof, SecurityParams,
+    };
+
+    /// Create random commitment
+    pub fn commit<C: Curve, R: RngCore>(
+        aux: &Aux,
+        data: Data<C>,
+        pdata: PrivateData,
+        security: &SecurityParams,
+        rng: &mut R,
+    ) -> Result<(Commitment<C>, PrivateCommitment), Error> {
+        let two_to_l_plus_e = (Integer::ONE << (security.l + security.epsilon)).complete();
+        let hat_n_at_two_to_l = (Integer::ONE << security.l).complete() * &aux.rsa_modulo;
+        let hat_n_at_two_to_l_plus_e =
+            (Integer::ONE << (security.l + security.epsilon)).complete() * &aux.rsa_modulo;
+
+        let alpha = Integer::from_rng_pm(&two_to_l_plus_e, rng);
+        let mu = Integer::from_rng_pm(&hat_n_at_two_to_l, rng);
+        let r = Integer::gen_invertible(data.key.n(), rng);
+        let beta = Integer::gen_invertible(&Integer::curve_order::<C>(), rng);
+        let gamma = Integer::from_rng_pm(&hat_n_at_two_to_l_plus_e, rng);
+
+        let s = aux.combine(pdata.plaintext, &mu)?;
+        let t = aux.combine(&alpha, &gamma)?;
+        let d = data.key.encrypt_with(&alpha, &r)?;
+        let y = data.g_to_a * beta.to_scalar() + Point::<C>::generator() * alpha.to_scalar();
+        let z = Point::<C>::generator() * beta.to_scalar();
+
+        Ok((
+            Commitment { s, t, d, y, z },
+            PrivateCommitment {
+                alpha,
+                mu,
+                r,
+                beta,
+                gamma,
+            },
+        ))
+    }
+
+    /// Compute proof for given data and prior protocol values
+    pub fn prove<C: Curve>(
+        data: Data<C>,
+        pdata: PrivateData,
+        private_commitment: &PrivateCommitment,
+        challenge: &Challenge,
+    ) -> Result<Proof, Error> {
+        let z1 = (&private_commitment.alpha + (challenge * pdata.plaintext)).complete();
+        let w = ((&private_commitment.beta + (challenge * pdata.b)).complete())
+            .modulo(&Integer::curve_order::<C>());
+        let nonce_to_challenge_mod_n: Integer = pdata
+            .nonce
+            .pow_mod_ref(challenge, data.key.n())
+            .ok_or(BadExponent::undefined())?
+            .into();
+        let z2 = (&private_commitment.r * nonce_to_challenge_mod_n).modulo(data.key.n());
+        let z3 = (&private_commitment.gamma + (challenge * &private_commitment.mu)).complete();
+        Ok(Proof { z1, z2, z3, w })
+    }
+
+    /// Verify the proof
+    pub fn verify<C: Curve>(
+        aux: &Aux,
+        data: Data<C>,
+        commitment: &Commitment<C>,
+        security: &SecurityParams,
+        challenge: &Challenge,
+        proof: &Proof,
+    ) -> Result<(), InvalidProof> {
+        {
+            let lhs = data
+                .key
+                .encrypt_with(&proof.z1, &proof.z2)
+                .map_err(|_| InvalidProofReason::PaillierEnc)?;
+            let rhs = {
+                let e_at_c = data
+                    .key
+                    .omul(challenge, data.ciphertext)
+                    .map_err(|_| InvalidProofReason::PaillierOp)?;
+                data.key
+                    .oadd(&commitment.d, &e_at_c)
+                    .map_err(|_| InvalidProofReason::PaillierOp)?
+            };
+            fail_if_ne(InvalidProofReason::EqualityCheck(1), lhs, rhs)?;
+        }
+        {
+            let lhs =
+                data.g_to_a * proof.w.to_scalar() + Point::<C>::generator() * proof.z1.to_scalar();
+            let rhs = commitment.y + data.g_to_ab_plus_x * challenge.to_scalar();
+            fail_if_ne(InvalidProofReason::EqualityCheck(2), lhs, rhs)?;
+        }
+        {
+            let lhs = Point::<C>::generator() * proof.w.to_scalar();
+            let rhs = commitment.z + data.g_to_b * challenge.to_scalar();
+            fail_if_ne(InvalidProofReason::EqualityCheck(3), lhs, rhs)?;
+        }
+        {
+            let lhs = aux.combine(&proof.z1, &proof.z3)?;
+            let s_to_e = aux.pow_mod(&commitment.s, challenge)?;
+            let rhs = (&commitment.t * s_to_e).modulo(&aux.rsa_modulo);
+            fail_if_ne(InvalidProofReason::EqualityCheck(4), lhs, rhs)?;
+        }
+
+        fail_if(
+            InvalidProofReason::RangeCheck(5),
+            proof
+                .z1
+                .is_in_pm(&(Integer::ONE << (security.l + security.epsilon)).complete()),
+        )?;
+
+        Ok(())
+    }
+
+    /// Generate random challenge
+    ///
+    /// `security` parameter is used to generate challenge in correct range
+    pub fn challenge<R: RngCore>(security: &SecurityParams, rng: &mut R) -> Challenge {
+        Integer::from_rng_pm(&security.q, rng)
+    }
+}
+
+/// The non-interactive version of proof. Completed in one round, for example
+/// see the documentation of parent module.
+pub mod non_interactive {
+    use digest::Digest;
+    use generic_ec::Curve;
+
+    use crate::{Error, InvalidProof};
+
+    use super::{Aux, Challenge, Commitment, Data, PrivateData, Proof, SecurityParams};
+
+    /// Compute proof for the given data, producing random commitment and
+    /// deriving determenistic challenge.
+    ///
+    /// Obtained from the above interactive proof via Fiat-Shamir heuristic.
+    pub fn prove<C: Curve, D: Digest>(
+        shared_state: &impl udigest::Digestable,
+        aux: &Aux,
+        data: Data<C>,
+        pdata: PrivateData,
+        security: &SecurityParams,
+        rng: &mut impl rand_core::RngCore,
+    ) -> Result<(Commitment<C>, Proof), Error> {
+        let (comm, pcomm) = super::interactive::commit(aux, data, pdata, security, rng)?;
+        let challenge = challenge::<C, D>(shared_state, aux, data, &comm, security);
+        let proof = super::interactive::prove(data, pdata, &pcomm, &challenge)?;
+        Ok((comm, proof))
+    }
+
+    /// Verify the proof, deriving challenge independently from same data
+    pub fn verify<C: Curve, D: Digest>(
+        shared_state: &impl udigest::Digestable,
+        aux: &Aux,
+        data: Data<C>,
+        commitment: &Commitment<C>,
+        security: &SecurityParams,
+        proof: &Proof,
+    ) -> Result<(), InvalidProof> {
+        let challenge = challenge::<C, D>(shared_state, aux, data, commitment, security);
+        super::interactive::verify(aux, data, commitment, security, &challenge, proof)
+    }
+
+    /// Deterministically compute challenge based on prior known values in protocol
+    pub fn challenge<C: Curve, D: Digest>(
+        shared_state: &impl udigest::Digestable,
+        aux: &Aux,
+        data: Data<C>,
+        commitment: &Commitment<C>,
+        security: &SecurityParams,
+    ) -> Challenge {
+        let tag = "paillier_zk.encryption_in_range_with_el_gamal.ni_challenge";
+        let aux = aux.digest_public_data();
+        let seed = udigest::inline_struct!(tag {
+            shared_state,
+            aux,
+            security,
+            data,
+            commitment,
+        });
+        let mut rng = rand_hash::HashRng::<D, _>::from_seed(seed);
+        super::interactive::challenge(security, &mut rng)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use generic_ec::{Curve, Point};
+    use rug::{Complete, Integer};
+    use sha2::Digest;
+
+    use crate::common::{IntegerExt, InvalidProofReason};
+
+    fn run_with<C: Curve, D: Digest>(
+        mut rng: &mut impl rand_core::CryptoRngCore,
+        security: super::SecurityParams,
+        plaintext: Integer,
+        a: Integer,
+        b: Integer,
+    ) -> Result<(), crate::common::InvalidProof> {
+        let aux = crate::common::test::aux(&mut rng);
+        let private_key = crate::common::test::random_key(&mut rng).unwrap();
+        let key = private_key.encryption_key();
+        let (ciphertext, nonce) = key.encrypt_with_random(&mut rng, &plaintext).unwrap();
+        let g_to_a = Point::<C>::generator() * a.to_scalar();
+        let g_to_b = Point::<C>::generator() * b.to_scalar();
+        let exponent = (&a * &b + &plaintext).complete();
+        let g_to_exponent = Point::<C>::generator() * exponent.to_scalar();
+        let data = super::Data {
+            key,
+            ciphertext: &ciphertext,
+            g_to_a: &g_to_a,
+            g_to_b: &g_to_b,
+            g_to_ab_plus_x: &g_to_exponent,
+        };
+        let pdata = super::PrivateData {
+            plaintext: &plaintext,
+            nonce: &nonce,
+            a: &a,
+            b: &b,
+        };
+
+        let shared_state = "shared state";
+        let (commitment, proof) =
+            super::non_interactive::prove::<C, D>(&shared_state, &aux, data, pdata, &security, rng)
+                .unwrap();
+        super::non_interactive::verify::<C, D>(
+            &shared_state,
+            &aux,
+            data,
+            &commitment,
+            &security,
+            &proof,
+        )
+    }
+
+    fn passing_test<C: Curve, D: Digest>() {
+        let mut rng = rand_dev::DevRng::new();
+        let security = super::SecurityParams {
+            l: 1024,
+            epsilon: 300,
+            q: (Integer::ONE << 128_u32).into(),
+        };
+        let plaintext = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
+        let a = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
+        let b = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
+        run_with::<C, D>(&mut rng, security, plaintext, a, b).expect("proof failed");
+    }
+
+    fn failing_test<C: Curve, D: Digest>() {
+        let mut rng = rand_dev::DevRng::new();
+        let security = super::SecurityParams {
+            l: 1024,
+            epsilon: 300,
+            q: (Integer::ONE << 128_u32).complete(),
+        };
+        let plaintext = (Integer::ONE << (security.l + security.epsilon)).complete() + 1;
+        let a = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
+        let b = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
+        let r = run_with::<C, D>(&mut rng, security, plaintext, a, b)
+            .expect_err("proof should not pass");
+        match r.reason() {
+            InvalidProofReason::RangeCheck(5) => (),
+            e => panic!("proof should not fail with: {e:?}"),
+        }
+    }
+
+    #[test]
+    fn passing_p256() {
+        passing_test::<generic_ec::curves::Secp256r1, sha2::Sha256>()
+    }
+    #[test]
+    fn failing_p256_add() {
+        failing_test::<generic_ec::curves::Secp256r1, sha2::Sha256>()
+    }
+
+    #[test]
+    fn passing_million() {
+        passing_test::<crate::curve::C, sha2::Sha256>()
+    }
+    #[test]
+    fn failing_million_add() {
+        failing_test::<crate::curve::C, sha2::Sha256>()
+    }
+}

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -251,9 +251,6 @@ pub mod interactive {
     ) -> Result<Proof<E>, Error> {
         let z1 = (&private_commitment.alpha + (challenge * pdata.plaintext)).complete();
         let z2 = {
-            // TODO: exp mod N can be faster if N=pq is known, but `dyn AnyEncryptionKey` doesn't provide
-            // a method for this. However, it's not yet clear to me if in the protocol at the time of proving,
-            // prover knows N=pq
             let nonce_to_challenge_mod_n: Integer = pdata
                 .nonce
                 .pow_mod_ref(challenge, data.key.n())

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -143,7 +143,7 @@ pub struct PrivateData<'a, E: Curve> {
     pub plaintext: &'a Plaintext,
     /// $\rho$ in paper
     pub nonce: &'a Nonce,
-
+    /// $b$ in paper
     pub b: &'a Scalar<E>,
 }
 

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -262,7 +262,7 @@ pub mod interactive {
             (&private_commitment.r * nonce_to_challenge_mod_n).modulo(data.key.n())
         };
         let z3 = (&private_commitment.gamma + (challenge * &private_commitment.mu)).complete();
-        let w = &private_commitment.beta + (challenge.to_scalar() * pdata.b);
+        let w = private_commitment.beta + (challenge.to_scalar() * pdata.b);
         Ok(Proof { z1, z2, z3, w })
     }
 

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -4,27 +4,30 @@
 //!
 //! ## Description
 //!
-//! A party P has `key` - public key in paillier
-//! cryptosystem. P also has `plaintext`, `nonce`,`a`,`b` and
-//! `ciphertext = key.encrypt_with(plaintext, nonce)`,
-//! `g_to_a = Point::<E>::generator() * a.to_scalar()`,
-//! `g_to_b = Point::<E>::generator() * b.to_scalar()`
-//! `g_to_ab_plus_x = Point::<E>::generator() * ((&a * &b + &plaintext).complete()).to_scalar()`
+//! Common (public) inputs: verifier's [`Aux`] data, [`SecurityParams`] containing
+//! $\ell$ and $\varepsilon$, [curve `E`](Curve), Paillier public `key`, a `ciphertext`,
+//! and elliptic points $A, B, X$.
 //!
-//! P wants to prove that `plaintext` is at most `l` bits, without disclosing
-//! it, the `nonce`,`a`, and `b`
-
+//! Prover secret inputs: `plaintext`, `nonce`, scalars $a, b$, such that:
+//! * `plaintext` $\in \pm 2^\ell$
+//! * `ciphertext == key.encrypt_with(plaintext, nonce)`
+//! * $A = a \cdot G$
+//! * $B = b \cdot G$
+//! * $X = (a b + \text{plaintext}) \cdot G$
+//!
+//! Proof guarantees that `plaintext` $\in \pm 2^{\ell + \varepsilon}$.
+//!
 //! ## Example
 //!
 //! ```
 //! use paillier_zk::{paillier_encryption_in_range_with_el_gamal as p, IntegerExt};
 //! use rug::{Integer, Complete};
-//! use generic_ec::{Point, curves::Secp256k1 as E};
+//! use generic_ec::{Point, Scalar, curves::Secp256k1 as E};
 //! # mod pregenerated {
 //! #     use super::*;
 //! #     paillier_zk::load_pregenerated_data!(
 //! #         verifier_aux: p::Aux,
-//! #         prover_decryption_key: fast_paillier::DecryptionKey,
+//! #         someone_encryption_key: fast_paillier::EncryptionKey,
 //! #     );
 //! # }
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -34,60 +37,51 @@
 //! let mut rng = rand_core::OsRng;
 //! # let mut rng = rand_dev::DevRng::new();
 //!
-//! // 0. Setup: prover and verifier share common Ring-Pedersen parameters:
-//!
+//! // Both parties know predefined security parameters and verifier's aux data
 //! let aux: p::Aux = pregenerated::verifier_aux();
 //! let security = p::SecurityParams {
 //!     l: 1024,
 //!     epsilon: 128,
-//!     q: (Integer::ONE << 128_u32).into(),
+//! };
+//! // ...and someone's encryption key
+//! let key: fast_paillier::EncryptionKey =
+//!     pregenerated::someone_encryption_key();
+//!
+//! // Prover knows its secret `pdata` and `a`
+//! let a = Scalar::random(&mut rng);
+//! let pdata = p::PrivateData {
+//!     plaintext: &Integer::from_rng_pm(&(Integer::ONE << security.l).complete(), &mut rng),
+//!     nonce: &Integer::gen_invertible(key.n(), &mut rng),
+//!     b: &Scalar::random(&mut rng),
 //! };
 //!
-//! // 1. Setup: prover prepares the paillier keys
+//! // Both parties know the public data
+//! let data = p::Data {
+//!     key: &key,
+//!     ciphertext: &key
+//!         .encrypt_with(pdata.plaintext, pdata.nonce)
+//!         .unwrap(),
+//!     a: &(Point::generator() * a),
+//!     b: &(Point::generator() * pdata.b),
+//!     x: &(Point::generator() * (a * pdata.b + pdata.plaintext.to_scalar())),
+//! };
 //!
-//! let private_key: fast_paillier::DecryptionKey =
-//!     pregenerated::prover_decryption_key();
-//! let key = private_key.encryption_key();
-//!
-//! // 2. Setup: prover has some plaintext and encrypts it
-//!
-//! let plaintext = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
-//! let (ciphertext, nonce) = key.encrypt_with_random(&mut rng, &plaintext)?;
-//!
-//! let a = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
-//! let b = Integer::from_rng_pm(&Integer::curve_order::<E>(), &mut rng);
-//!
-//! let g_to_a = Point::<E>::generator() * a.to_scalar();
-//! let g_to_b = Point::<E>::generator() * b.to_scalar();
-//! let exponent = (&a * &b + &plaintext).complete();
-//! let g_to_ab_plus_x = Point::<E>::generator() * exponent.to_scalar();
-//!
-//! // 3. Prover computes a non-interactive proof that plaintext is at most 1024 bits:
-//!
-//! let data = p::Data { key, ciphertext: &ciphertext , g_to_a: &g_to_a,
-//!     g_to_b: &g_to_b ,g_to_ab_plus_x: &g_to_ab_plus_x};
-//! let (commitment, proof) = p::non_interactive::prove::<E,sha2::Sha256>(
+//! // Prover computes a non-interactive proof:
+//! let (commitment, proof) = p::non_interactive::prove::<E, sha2::Sha256>(
 //!     &shared_state,
 //!     &aux,
 //!     data,
-//!     p::PrivateData {
-//!         plaintext: &plaintext,
-//!         nonce: &nonce,
-//!         a: &a,
-//!         b:&b
-//!     },
+//!     pdata,
 //!     &security,
 //!     &mut rng,
 //! )?;
 //!
-//! // 4. Prover sends this data to verifier
-//!
+//! // Prover sends this data to verifier
 //! # use generic_ec::Curve;
-//! # fn send<E: Curve>(_: &p::Data<E>, _: &p::Commitment<E>, _: &p::Proof) {  }
+//! # fn send<E: Curve>(_: &p::Data<E>, _: &p::Commitment<E>, _: &p::Proof<E>) {  }
 //! send(&data, &commitment, &proof);
 //!
-//! // 5. Verifier receives the data and the proof and verifies it
-//!
+//! // Verifier receives the data and the proof and verifies it
 //! # let recv = || (data, commitment, proof);
 //! let (data, commitment, proof) = recv();
 //! p::non_interactive::verify::<E, sha2::Sha256>(
@@ -95,16 +89,16 @@
 //!     &aux,
 //!     data,
 //!     &commitment,
-//!     &security,
 //!     &proof,
+//!     &security,
 //! );
 //! # Ok(()) }
 //! ```
 //!
 //! If the verification succeeded, verifier can continue communication with prover
 
-use fast_paillier::{AnyEncryptionKey, Ciphertext, Nonce};
-use generic_ec::{Curve, Point};
+use fast_paillier::{AnyEncryptionKey, Ciphertext, Nonce, Plaintext};
+use generic_ec::{Curve, Point, Scalar};
 use rug::Integer;
 
 #[cfg(feature = "serde")]
@@ -114,75 +108,67 @@ pub use crate::common::Aux;
 pub use crate::common::InvalidProof;
 
 /// Security parameters for proof. Choosing the values is a tradeoff between
-/// speed and chance of rejecting a valid proof or accepting an invalid proof
+/// security, speed and correctness
 #[derive(Debug, Clone, udigest::Digestable)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SecurityParams {
-    /// l in paper, security parameter for bit size of plaintext: it needs to
-    /// be in range [-2^l; 2^l] or equivalently 2^l
+    /// $\ell$ in paper
     pub l: usize,
-    /// Epsilon in paper, slackness parameter
+    /// $\varepsilon$ in paper, slackness parameter
     pub epsilon: usize,
-    /// q in paper. Security parameter for challenge
-    #[udigest(as = crate::common::encoding::Integer)]
-    pub q: Integer,
 }
 
 /// Public data that both parties know
 #[derive(Debug, Clone, Copy, udigest::Digestable)]
 #[udigest(bound = "")]
 pub struct Data<'a, C: Curve> {
-    /// N0 in paper, public key that x -> C was encrypted on
+    /// $N_0$ in paper
     #[udigest(as = crate::common::encoding::AnyEncryptionKey)]
     pub key: &'a dyn AnyEncryptionKey,
-    /// C in paper
+    /// $C$ in paper
     #[udigest(as = &crate::common::encoding::Integer)]
     pub ciphertext: &'a Ciphertext,
-    /// A=g^a in paper
-    pub g_to_a: &'a Point<C>,
-    /// B=g^b in paper
-    pub g_to_b: &'a Point<C>,
-    /// X=g^{ab+x} in paper
-    pub g_to_ab_plus_x: &'a Point<C>,
+    /// $A$ in paper
+    pub a: &'a Point<C>,
+    /// $B$ in paper
+    pub b: &'a Point<C>,
+    /// $X$ in paper
+    pub x: &'a Point<C>,
 }
 
 /// Private data of prover
 #[derive(Clone, Copy)]
-pub struct PrivateData<'a> {
-    /// x in paper, plaintext of C
-    pub plaintext: &'a Integer,
-    /// rho in paper, nonce of encryption x -> C
+pub struct PrivateData<'a, E: Curve> {
+    /// $x$ in paper
+    pub plaintext: &'a Plaintext,
+    /// $\rho$ in paper
     pub nonce: &'a Nonce,
-    /// a in paper, preimage of A
-    pub a: &'a Integer,
-    /// b in paper, preimage of B
-    pub b: &'a Integer,
+
+    pub b: &'a Scalar<E>,
 }
 
-// As described in cggmp24 at page 58
-/// Prover's first message, obtained by [`interactive::commit`]
+/// Prover's public commitment
 #[derive(Debug, Clone, udigest::Digestable)]
 #[udigest(bound = "")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Commitment<C: Curve> {
+pub struct Commitment<E: Curve> {
     #[udigest(as = crate::common::encoding::Integer)]
     pub s: Integer,
     #[udigest(as = crate::common::encoding::Integer)]
     pub t: Integer,
     #[udigest(as = crate::common::encoding::Integer)]
     pub d: Integer,
-    pub y: Point<C>,
-    pub z: Point<C>,
+    pub y: Point<E>,
+    pub z: Point<E>,
 }
 
-/// Prover's data accompanying the commitment. Kept as state between rounds in
-/// the interactive protocol.
+/// Prover's secret commitment nonce
 #[derive(Clone)]
-pub struct PrivateCommitment {
+pub struct PrivateCommitment<E: Curve> {
     pub alpha: Integer,
     pub mu: Integer,
     pub r: Integer,
-    pub beta: Integer,
+    pub beta: Scalar<E>,
     pub gamma: Integer,
 }
 
@@ -190,23 +176,21 @@ pub struct PrivateCommitment {
 /// [`non_interactive::challenge`] or randomly by [`interactive::challenge`]
 pub type Challenge = Integer;
 
-// As described in cggmp24 at page 58
-/// The ZK proof. Computed by [`interactive::prove`] or
-/// [`non_interactive::prove`]
+/// Range Proof with El-Gamal commitment
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Proof {
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(bound = ""))]
+pub struct Proof<E: Curve> {
     pub z1: Integer,
     pub z2: Integer,
     pub z3: Integer,
-    pub w: Integer,
+    pub w: Scalar<E>,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
 /// prover commits to data, verifier responds with a random challenge, and
 /// prover gives proof with commitment and challenge.
 pub mod interactive {
-    use generic_ec::{Curve, Point};
+    use generic_ec::{Curve, Point, Scalar};
     use rand_core::RngCore;
     use rug::{Complete, Integer};
 
@@ -222,29 +206,29 @@ pub mod interactive {
     };
 
     /// Create random commitment
-    pub fn commit<C: Curve, R: RngCore>(
+    pub fn commit<E: Curve>(
         aux: &Aux,
-        data: Data<C>,
-        pdata: PrivateData,
+        data: Data<E>,
+        pdata: PrivateData<E>,
         security: &SecurityParams,
-        rng: &mut R,
-    ) -> Result<(Commitment<C>, PrivateCommitment), Error> {
+        rng: &mut impl RngCore,
+    ) -> Result<(Commitment<E>, PrivateCommitment<E>), Error> {
         let two_to_l_plus_e = (Integer::ONE << (security.l + security.epsilon)).complete();
-        let hat_n_at_two_to_l = (Integer::ONE << security.l).complete() * &aux.rsa_modulo;
-        let hat_n_at_two_to_l_plus_e =
+        let n_j_at_two_to_l = (Integer::ONE << security.l).complete() * &aux.rsa_modulo;
+        let n_j_at_two_to_l_plus_e =
             (Integer::ONE << (security.l + security.epsilon)).complete() * &aux.rsa_modulo;
 
         let alpha = Integer::from_rng_pm(&two_to_l_plus_e, rng);
-        let mu = Integer::from_rng_pm(&hat_n_at_two_to_l, rng);
+        let mu = Integer::from_rng_pm(&n_j_at_two_to_l, rng);
         let r = Integer::gen_invertible(data.key.n(), rng);
-        let beta = Integer::gen_invertible(&Integer::curve_order::<C>(), rng);
-        let gamma = Integer::from_rng_pm(&hat_n_at_two_to_l_plus_e, rng);
+        let beta = Scalar::random(rng);
+        let gamma = Integer::from_rng_pm(&n_j_at_two_to_l_plus_e, rng);
 
         let s = aux.combine(pdata.plaintext, &mu)?;
         let t = aux.combine(&alpha, &gamma)?;
         let d = data.key.encrypt_with(&alpha, &r)?;
-        let y = data.g_to_a * beta.to_scalar() + Point::<C>::generator() * alpha.to_scalar();
-        let z = Point::<C>::generator() * beta.to_scalar();
+        let y = data.a * beta + Point::<E>::generator() * alpha.to_scalar();
+        let z = Point::<E>::generator() * beta;
 
         Ok((
             Commitment { s, t, d, y, z },
@@ -259,33 +243,37 @@ pub mod interactive {
     }
 
     /// Compute proof for given data and prior protocol values
-    pub fn prove<C: Curve>(
-        data: Data<C>,
-        pdata: PrivateData,
-        private_commitment: &PrivateCommitment,
+    pub fn prove<E: Curve>(
+        data: Data<E>,
+        pdata: PrivateData<E>,
+        private_commitment: &PrivateCommitment<E>,
         challenge: &Challenge,
-    ) -> Result<Proof, Error> {
+    ) -> Result<Proof<E>, Error> {
         let z1 = (&private_commitment.alpha + (challenge * pdata.plaintext)).complete();
-        let w = ((&private_commitment.beta + (challenge * pdata.b)).complete())
-            .modulo(&Integer::curve_order::<C>());
-        let nonce_to_challenge_mod_n: Integer = pdata
-            .nonce
-            .pow_mod_ref(challenge, data.key.n())
-            .ok_or(BadExponent::undefined())?
-            .into();
-        let z2 = (&private_commitment.r * nonce_to_challenge_mod_n).modulo(data.key.n());
+        let z2 = {
+            // TODO: exp mod N can be faster if N=pq is known, but `dyn AnyEncryptionKey` doesn't provide
+            // a method for this. However, it's not yet clear to me if in the protocol at the time of proving,
+            // prover knows N=pq
+            let nonce_to_challenge_mod_n: Integer = pdata
+                .nonce
+                .pow_mod_ref(challenge, data.key.n())
+                .ok_or(BadExponent::undefined())?
+                .into();
+            (&private_commitment.r * nonce_to_challenge_mod_n).modulo(data.key.n())
+        };
         let z3 = (&private_commitment.gamma + (challenge * &private_commitment.mu)).complete();
+        let w = &private_commitment.beta + (challenge.to_scalar() * pdata.b);
         Ok(Proof { z1, z2, z3, w })
     }
 
     /// Verify the proof
-    pub fn verify<C: Curve>(
+    pub fn verify<E: Curve>(
         aux: &Aux,
-        data: Data<C>,
-        commitment: &Commitment<C>,
+        data: Data<E>,
+        commitment: &Commitment<E>,
         security: &SecurityParams,
         challenge: &Challenge,
-        proof: &Proof,
+        proof: &Proof<E>,
     ) -> Result<(), InvalidProof> {
         {
             let lhs = data
@@ -304,20 +292,21 @@ pub mod interactive {
             fail_if_ne(InvalidProofReason::EqualityCheck(1), lhs, rhs)?;
         }
         {
-            let lhs =
-                data.g_to_a * proof.w.to_scalar() + Point::<C>::generator() * proof.z1.to_scalar();
-            let rhs = commitment.y + data.g_to_ab_plus_x * challenge.to_scalar();
+            let lhs = data.a * proof.w + Point::<E>::generator() * proof.z1.to_scalar();
+            let rhs = commitment.y + data.x * challenge.to_scalar();
             fail_if_ne(InvalidProofReason::EqualityCheck(2), lhs, rhs)?;
         }
         {
-            let lhs = Point::<C>::generator() * proof.w.to_scalar();
-            let rhs = commitment.z + data.g_to_b * challenge.to_scalar();
+            let lhs = Point::<E>::generator() * proof.w;
+            let rhs = commitment.z + data.b * challenge.to_scalar();
             fail_if_ne(InvalidProofReason::EqualityCheck(3), lhs, rhs)?;
         }
         {
             let lhs = aux.combine(&proof.z1, &proof.z3)?;
-            let s_to_e = aux.pow_mod(&commitment.s, challenge)?;
-            let rhs = (&commitment.t * s_to_e).modulo(&aux.rsa_modulo);
+            let rhs = {
+                let s_to_e = aux.pow_mod(&commitment.s, challenge)?;
+                (&commitment.t * s_to_e).modulo(&aux.rsa_modulo)
+            };
             fail_if_ne(InvalidProofReason::EqualityCheck(4), lhs, rhs)?;
         }
 
@@ -334,8 +323,8 @@ pub mod interactive {
     /// Generate random challenge
     ///
     /// `security` parameter is used to generate challenge in correct range
-    pub fn challenge<R: RngCore>(security: &SecurityParams, rng: &mut R) -> Challenge {
-        Integer::from_rng_pm(&security.q, rng)
+    pub fn challenge<E: Curve>(rng: &mut impl RngCore) -> Challenge {
+        Integer::from_rng_pm(&Integer::curve_order::<E>(), rng)
     }
 }
 
@@ -350,106 +339,101 @@ pub mod non_interactive {
     use super::{Aux, Challenge, Commitment, Data, PrivateData, Proof, SecurityParams};
 
     /// Compute proof for the given data, producing random commitment and
-    /// deriving determenistic challenge.
+    /// deriving deterministic challenge.
     ///
     /// Obtained from the above interactive proof via Fiat-Shamir heuristic.
-    pub fn prove<C: Curve, D: Digest>(
+    pub fn prove<E: Curve, D: Digest>(
         shared_state: &impl udigest::Digestable,
         aux: &Aux,
-        data: Data<C>,
-        pdata: PrivateData,
+        data: Data<E>,
+        pdata: PrivateData<E>,
         security: &SecurityParams,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<(Commitment<C>, Proof), Error> {
+    ) -> Result<(Commitment<E>, Proof<E>), Error> {
         let (comm, pcomm) = super::interactive::commit(aux, data, pdata, security, rng)?;
-        let challenge = challenge::<C, D>(shared_state, aux, data, &comm, security);
+        let challenge = challenge::<E, D>(shared_state, aux, data, &comm, security);
         let proof = super::interactive::prove(data, pdata, &pcomm, &challenge)?;
         Ok((comm, proof))
     }
 
     /// Verify the proof, deriving challenge independently from same data
-    pub fn verify<C: Curve, D: Digest>(
+    pub fn verify<E: Curve, D: Digest>(
         shared_state: &impl udigest::Digestable,
         aux: &Aux,
-        data: Data<C>,
-        commitment: &Commitment<C>,
+        data: Data<E>,
+        commitment: &Commitment<E>,
+        proof: &Proof<E>,
         security: &SecurityParams,
-        proof: &Proof,
     ) -> Result<(), InvalidProof> {
-        let challenge = challenge::<C, D>(shared_state, aux, data, commitment, security);
+        let challenge = challenge::<E, D>(shared_state, aux, data, commitment, security);
         super::interactive::verify(aux, data, commitment, security, &challenge, proof)
     }
 
     /// Deterministically compute challenge based on prior known values in protocol
-    pub fn challenge<C: Curve, D: Digest>(
+    pub fn challenge<E: Curve, D: Digest>(
         shared_state: &impl udigest::Digestable,
         aux: &Aux,
-        data: Data<C>,
-        commitment: &Commitment<C>,
+        data: Data<E>,
+        commitment: &Commitment<E>,
         security: &SecurityParams,
     ) -> Challenge {
         let tag = "paillier_zk.encryption_in_range_with_el_gamal.ni_challenge";
-        let aux = aux.digest_public_data();
         let seed = udigest::inline_struct!(tag {
             shared_state,
-            aux,
+            aux: aux.digest_public_data(),
             security,
             data,
             commitment,
         });
         let mut rng = rand_hash::HashRng::<D, _>::from_seed(seed);
-        super::interactive::challenge(security, &mut rng)
+        super::interactive::challenge::<E>(&mut rng)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use generic_ec::{Curve, Point};
+    use generic_ec::{Curve, Point, Scalar};
     use rug::{Complete, Integer};
     use sha2::Digest;
 
     use crate::common::{IntegerExt, InvalidProofReason};
 
-    fn run_with<C: Curve, D: Digest>(
+    fn run_with<E: Curve, D: Digest>(
         mut rng: &mut impl rand_core::CryptoRngCore,
         security: super::SecurityParams,
         plaintext: Integer,
-        a: Integer,
-        b: Integer,
     ) -> Result<(), crate::common::InvalidProof> {
         let aux = crate::common::test::aux(&mut rng);
+
         let private_key = crate::common::test::random_key(&mut rng).unwrap();
-        let key = private_key.encryption_key();
-        let (ciphertext, nonce) = key.encrypt_with_random(&mut rng, &plaintext).unwrap();
-        let g_to_a = Point::<C>::generator() * a.to_scalar();
-        let g_to_b = Point::<C>::generator() * b.to_scalar();
-        let exponent = (&a * &b + &plaintext).complete();
-        let g_to_exponent = Point::<C>::generator() * exponent.to_scalar();
-        let data = super::Data {
-            key,
-            ciphertext: &ciphertext,
-            g_to_a: &g_to_a,
-            g_to_b: &g_to_b,
-            g_to_ab_plus_x: &g_to_exponent,
-        };
+        let a = Scalar::random(rng);
         let pdata = super::PrivateData {
             plaintext: &plaintext,
-            nonce: &nonce,
-            a: &a,
-            b: &b,
+            nonce: &Integer::gen_invertible(private_key.n(), rng),
+            b: &Scalar::random(rng),
+        };
+
+        let data = super::Data {
+            key: private_key.encryption_key(),
+            ciphertext: &private_key
+                .encrypt_with(pdata.plaintext, pdata.nonce)
+                .unwrap(),
+            a: &(Point::generator() * a),
+            b: &(Point::generator() * pdata.b),
+            x: &(Point::generator() * (a * pdata.b + pdata.plaintext.to_scalar())),
         };
 
         let shared_state = "shared state";
         let (commitment, proof) =
-            super::non_interactive::prove::<C, D>(&shared_state, &aux, data, pdata, &security, rng)
+            super::non_interactive::prove::<E, D>(&shared_state, &aux, data, pdata, &security, rng)
                 .unwrap();
-        super::non_interactive::verify::<C, D>(
+        super::non_interactive::verify::<E, D>(
             &shared_state,
             &aux,
             data,
             &commitment,
-            &security,
             &proof,
+            &security,
         )
     }
 
@@ -458,12 +442,9 @@ mod test {
         let security = super::SecurityParams {
             l: 1024,
             epsilon: 300,
-            q: (Integer::ONE << 128_u32).into(),
         };
-        let plaintext = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
-        let a = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
-        let b = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
-        run_with::<C, D>(&mut rng, security, plaintext, a, b).expect("proof failed");
+        let plaintext = Integer::from_rng_pm(&(Integer::ONE << security.l).complete(), &mut rng);
+        run_with::<C, D>(&mut rng, security, plaintext).expect("proof failed");
     }
 
     fn failing_test<C: Curve, D: Digest>() {
@@ -471,13 +452,9 @@ mod test {
         let security = super::SecurityParams {
             l: 1024,
             epsilon: 300,
-            q: (Integer::ONE << 128_u32).complete(),
         };
         let plaintext = (Integer::ONE << (security.l + security.epsilon)).complete() + 1;
-        let a = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
-        let b = Integer::from_rng_pm(&Integer::curve_order::<C>(), &mut rng);
-        let r = run_with::<C, D>(&mut rng, security, plaintext, a, b)
-            .expect_err("proof should not pass");
+        let r = run_with::<C, D>(&mut rng, security, plaintext).expect_err("proof should not pass");
         match r.reason() {
             InvalidProofReason::RangeCheck(5) => (),
             e => panic!("proof should not fail with: {e:?}"),

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -215,8 +215,7 @@ pub mod interactive {
     ) -> Result<(Commitment<E>, PrivateCommitment<E>), Error> {
         let two_to_l_plus_e = (Integer::ONE << (security.l + security.epsilon)).complete();
         let n_j_at_two_to_l = (Integer::ONE << security.l).complete() * &aux.rsa_modulo;
-        let n_j_at_two_to_l_plus_e =
-            (Integer::ONE << (security.l + security.epsilon)).complete() * &aux.rsa_modulo;
+        let n_j_at_two_to_l_plus_e = (&two_to_l_plus_e * &aux.rsa_modulo).complete();
 
         let alpha = Integer::from_rng_pm(&two_to_l_plus_e, rng);
         let mu = Integer::from_rng_pm(&n_j_at_two_to_l, rng);

--- a/spec/main.tex
+++ b/spec/main.tex
@@ -1591,12 +1591,12 @@ Proof guarantees that $x \in \pm 2^{\ell + \varepsilon}$
 
 \item
 \begin{inlineAlgorithm}
-\algoName{$\prove{enc\mbox{-}elg}(N_0, e; (x, \rho), (\alpha, \mu, r, \beta, \gamma))
+\algoName{$\prove{enc\mbox{-}elg}(N_0, e; (x, \rho, b), (\alpha, \mu, r, \beta, \gamma))
     \to (z_1, z_2, z_3, w)$}
 \algoInputsList{
     \item (subset of) public inputs: $N_0 \in \Z$,
     \item challenge $e \in \Z_q$,
-    \item (subset of) secret data: $(x, \rho) \in (\Z, \Z)$,
+    \item (subset of) secret data: $(x, \rho, b) \in (\Z, \Z, \Z_q)$,
     \item secret commitment nonce: $(\alpha, \mu, r, \beta, \gamma) \in (\Z, \Z, \Z, \Z_q, \Z)$
 }
 \algoOutputs{proof $(z_1, z_2, z_3, w) \in (\Z, \Z_{N_0}, \Z, \Z_q)$}
@@ -1638,7 +1638,7 @@ Proof guarantees that $x \in \pm 2^{\ell + \varepsilon}$
 
 \item
 \begin{inlineAlgorithm}
-\algoName{$\proveni{enc\mbox{-}elg}^L(\state, R_j, (N_0, C, A, B, X); (x, \rho)) \to (
+\algoName{$\proveni{enc\mbox{-}elg}^L(\state, R_j, (N_0, C, A, B, X); (x, \rho, b)) \to (
     (S, T, D, Y, Z),
     (z_1, z_2, z_3, w)
 )$}
@@ -1647,7 +1647,7 @@ Proof guarantees that $x \in \pm 2^{\ell + \varepsilon}$
     \item shared $\state \in \Byte^*$,
     \item verifier's auxiliary data $R_j$,
     \item public data $(N_0, C, A, B, X) \in (\Z, \Z, \E, \E, \E)$,
-    \item (subset of) secret data $(x, \rho) \in \Z^2$,
+    \item (subset of) secret data $(x, \rho, b) \in (\Z, \Z, \Z_q)$,
 }
 \algoOutputsList{
     \item commitment $(S, T, D, Y, Z) \in (\Z^*_{N_j}, \Z^*_{N_j}, \Z^*_{N^2_0}, \E, \E)$,
@@ -1658,7 +1658,7 @@ Proof guarantees that $x \in \pm 2^{\ell + \varepsilon}$
     \gets \commit{enc\mbox{-}elg}^L(R_j, (N_0, A); x)$
 \State $e \in \pm q = \challengeni{enc\mbox{-}elg}^L(\state, (N_0, C, A, B, X), (S, T, D, Y, Z))$
 \State $(z_1, z_2, z_3, w)
-    = \prove{enc\mbox{-}elg}(N_0, e; (x, \rho), (\alpha, \mu, r, \beta, \gamma))$
+    = \prove{enc\mbox{-}elg}(N_0, e; (x, \rho, b), (\alpha, \mu, r, \beta, \gamma))$
 \State \Return $(
     (S, T, D, Y, Z),
     (z_1, z_2, z_3, w)

--- a/spec/main.tex
+++ b/spec/main.tex
@@ -1523,6 +1523,175 @@ We describe the standard Schnorr proof of knowledge, and also set up notation th
 
 \end{description}
 
+\subsection{$\proof{enc\mbox{-}elg}$: Range Proof with El-Gamal Commitment}
+
+Common (public) input:
+    security level $L = (\ell, \varepsilon, \dots)$,
+    verifier's auxilary data $R_j = (N_j, s_j, t_j) \in (\Z, \Z^*_{N_j}, \Z^*_{N_j})$,
+    curve $\E$ with generator $G$ of prime order $q$,
+    Paillier public key $N_0 \in \Z$,
+    Paillier ciphertext $C \in \Z^*_{N_0^2}$,
+    and commitments $(A, B, X) \in \E^3$.
+
+
+Prover secret input: $(x, \rho, a, b) \in (\pm 2^\ell, \Z^*_{N_0}, \Z_q, \Z_q)$ such that
+    $x \in \pm 2^\ell,
+    C = \enc_{N_0}(x, \rho),
+    A = a \cdot G,
+    B = b \cdot G,
+    X = (ab + x) \cdot G$.
+
+Proof guarantees that $x \in \pm 2^{\ell + \varepsilon}$
+
+\subsubsection{Interactive Version of the Proof}
+
+\begin{description}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\commit{enc\mbox{-}elg}^L(R_j, (N_0, A); x) \to ((S, T, D, Y, Z); (\alpha, \mu, r, \beta, \gamma))$}
+\algoInputsList{
+    \item security level $L = (\ell, \varepsilon, \dots)$,
+    \item verifier's auxiliary data $R_j = (N_j, s_j, t_j) \in \Z^3$,
+    \item (subset of) public data $(N_0, A) \in (\Z, \E)$
+    \item (subset of) secret data $x \in \Z$
+}
+\algoOutputsList{
+    \item public commitment $(S, T, D, Y, Z) \in (\Z^*_{N_j}, \Z^*_{N_j}, \Z^*_{N^2_0}, \E, \E)$,
+    \item secret nonce $(\alpha, \mu, r, \beta, \gamma) \in (\Z, \Z, \Z, \Z_q, \Z)$
+}
+\begin{algorithmic}[1]
+\State $\alpha \gets \pm 2^{\ell + \varepsilon}$
+\State $\mu \gets \pm 2^\ell \cdot N_j$
+\State $r \gets \Z^*_{N_0}$
+\State $\beta \gets \Z_q$
+\State $\gamma \gets \pm 2^{\ell + \varepsilon} \cdot N_j$
+\Statex
+\State $S = s_j^x t_j^\mu \bmod N_j$
+\State $T = s_j^\alpha t_j^\gamma \bmod N_j$
+    \Comment{$S,T$ are computed via fixed-base multiexp algorithm}
+\State $D = \enc_{N_0}(\alpha, r)$
+\State $Y = \beta \cdot A + \alpha G$
+\State $Z = \beta \cdot G$
+\Statex
+\State \Return $(S, T, D, Y, Z); (\alpha, \mu, r, \beta, \gamma)$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\challenge{enc\mbox{-}elg}() \to e$}
+\algoInputs{none}
+\algoOutputs{challenge $e \in \pm q$}
+\begin{algorithmic}[1]
+\State $e \gets \pm q$
+\State \Return $e$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\prove{enc\mbox{-}elg}(N_0, e; (x, \rho), (\alpha, \mu, r, \beta, \gamma))
+    \to (z_1, z_2, z_3, w)$}
+\algoInputsList{
+    \item (subset of) public inputs: $N_0 \in \Z$,
+    \item challenge $e \in \Z_q$,
+    \item (subset of) secret data: $(x, \rho) \in (\Z, \Z)$,
+    \item secret commitment nonce: $(\alpha, \mu, r, \beta, \gamma) \in (\Z, \Z, \Z, \Z_q, \Z)$
+}
+\algoOutputs{proof $(z_1, z_2, z_3, w) \in (\Z, \Z_{N_0}, \Z, \Z_q)$}
+\begin{algorithmic}[1]
+\State $z_1 = \alpha + e x$
+\State $z_2 = r \cdot \rho^e \bmod N_0$
+\State $z_3 = \gamma + e \mu$
+\State $w = \beta + e b \bmod q$
+\State \Return $(z_1, z_2, z_3, w)$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\verify{enc\mbox{-}elg}^L(R_j, (N_0, C, A, B, X), (S, T, D, Y, Z), e, (z_1, z_2, z_3, w))$}
+\algoInputsList{
+    \item security level $L = (\ell, \varepsilon, \dots)$,
+    \item prover's auxiliary data $R_j = (N_j, s_j, t_j) \in \Z^3$,
+    \item public data $(N_0, C, A, B, X) \in (\Z, \Z, \E, \E, \E)$,
+    \item commitment $(S, T, D, Y, Z) \in (\Z, \Z, \Z, \E, \E)$,
+    \item proof $(z_1, z_2, z_3, w) \in (\Z, \Z, \Z, \Z_q)$
+}
+\algoOutputs{aborts if proof is invalid}
+\begin{algorithmic}[1]
+\State $\enc_{N_0}(z_1, z_2) \? = D \oplus e \odot C$
+\State $w \cdot A + z_1 \cdot G \? = Y + e \cdot X$
+\State $w \cdot G \? = Z + e \cdot B$
+\State $s^{z_1} t^{z_3} \? = T \cdot S^e \bmod N_j$
+    \Comment{left part is computed via fixed-base multiexp}
+\State $z_1 \? \in \pm 2^{\ell + \varepsilon}$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\end{description}
+
+\subsubsection{Non-Interactive Version of the Proof}
+
+\begin{description}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\proveni{enc\mbox{-}elg}^L(\state, R_j, (N_0, C, A, B, X); (x, \rho)) \to (
+    (S, T, D, Y, Z),
+    (z_1, z_2, z_3, w)
+)$}
+\algoInputsList{
+    \item security level $L$,
+    \item shared $\state \in \Byte^*$,
+    \item verifier's auxiliary data $R_j$,
+    \item public data $(N_0, C, A, B, X) \in (\Z, \Z, \E, \E, \E)$,
+    \item (subset of) secret data $(x, \rho) \in \Z^2$,
+}
+\algoOutputsList{
+    \item commitment $(S, T, D, Y, Z) \in (\Z^*_{N_j}, \Z^*_{N_j}, \Z^*_{N^2_0}, \E, \E)$,
+    \item proof $(z_1, z_2, z_3, w) \in (\Z, \Z_{N_0}, \Z, \Z_q)$
+}
+\begin{algorithmic}[1]
+\State $((S, T, D, Y, Z); (\alpha, \mu, r, \beta, \gamma))
+    \gets \commit{enc\mbox{-}elg}^L(R_j, (N_0, A); x)$
+\State $e \in \pm q = \challengeni{enc\mbox{-}elg}^L(\state, (N_0, C, A, B, X), (S, T, D, Y, Z))$
+\State $(z_1, z_2, z_3, w)
+    = \prove{enc\mbox{-}elg}(N_0, e; (x, \rho), (\alpha, \mu, r, \beta, \gamma))$
+\State \Return $(
+    (S, T, D, Y, Z),
+    (z_1, z_2, z_3, w)
+)$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\item
+\begin{inlineAlgorithm}
+\algoName{$\verifyni{enc\mbox{-}elg}^L(\state, R_j, (N_0, C, A, B, X), (
+    (S, T, D, Y, Z),
+    (z_1, z_2, z_3, w)
+))$}
+\algoInputsList{
+    \item security level $L$,
+    \item shared $\state \in \Byte^*$,
+    \item verifier's auxiliary data $R_j$,
+    \item public data $(N_0, C, A, B, X) \in (\Z, \Z, \E, \E, \E)$,
+    \item non-interactive proof consisting of:
+        \begin{itemize}
+        \item commitment $(S, T, D, Y, Z) \in (\Z, \Z, \Z, \E, \E)$,
+        \item proof $(z_1, z_2, z_3, w) \in (\Z, \Z, \Z, \Z_q)$
+        \end{itemize}
+}
+\algoOutputs{aborts if proof is invalid}
+\begin{algorithmic}[1]
+\State $e \in \pm q = \challengeni{enc\mbox{-}elg}^L(R_j, (N_0, C, A, B, X), (S, T, D, Y, Z))$
+\State Assert $\verify{enc\mbox{-}elg}(R_j, (N_0, C, A, B, X), (S, T, D, Y, Z), e, (z_1, z_2, z_3, w))$
+\end{algorithmic}
+\end{inlineAlgorithm}
+
+\end{description}
+
 \section{Threshold Protocols}
 
 In this section we describe the various threshold protocols we have implemented. 


### PR DESCRIPTION
Moved from #132 originally authored by @manel1874

--------------

Implementation of Range Proof with El-Gamal commitment ZK $\prod^{enc-elg}$ in the new [cggmp24](https://eprint.iacr.org/2021/060.pdf) version.  

# Motivation

This is part of the ongoing effort to update the cggmp21 implementetion to the latest version. Changes required within the zkps:

### New protocols to be implemented:
- [x] `Discrete Log with El-Gamal commitment ZK` $\prod^{elog}$. #131 
- [x] `Range Proof with El-Gamal commitment ZK` $\prod^{enc-elg}$. This PR

### Protocols to be changed
- [x] `Paillier-Blum Modulus ZK` $\prod^{mod}$. #133 
- [x] `No Small Factor ZK` $\prod^{fac}$. #134 

### Protocols no longer used (to be deleted)
- [ ] `Paillier Encryption in Range ZK` $\prod^{enc}$