### PR TITLE
feat: update paillier blum modulus zkp to cggmp24 version

### DIFF
--- a/paillier-zk/src/common/sqrt.rs
+++ b/paillier-zk/src/common/sqrt.rs
@@ -1,6 +1,8 @@
 use rand_core::RngCore;
 use rug::{Complete, Integer};
 
+use super::IntegerExt;
+
 /// Find principal square root in a Blum modulus quotient ring.
 ///
 /// Pre-requisites:
@@ -56,12 +58,10 @@ pub fn find_residue(
     }
 }
 
-/// Finds a element in Zn that has jacobi symbol of -1
-pub fn sample_neg_jacobi<R: RngCore>(n: &Integer, rng: &mut R) -> Integer {
+/// Finds a element in Z*n that has jacobi symbol of -1
+pub fn sample_invertible_with_neg_jacobi<R: RngCore>(n: &Integer, rng: &mut R) -> Integer {
     loop {
-        let w = n
-            .clone()
-            .random_below(&mut fast_paillier::utils::external_rand(rng));
+        let w = Integer::gen_invertible(n, rng);
         if w.jacobi(n) == -1 {
             break w;
         }

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -123,9 +123,12 @@ pub mod interactive {
     use rand_core::RngCore;
     use rug::{Complete, Integer};
 
-    use crate::common::{
-        fail_if_ne,
-        sqrt::{blum_sqrt, find_residue, sample_neg_jacobi},
+    use crate::{
+        common::{
+            fail_if_ne,
+            sqrt::{blum_sqrt, find_residue, sample_neg_jacobi},
+        },
+        IntegerExt,
     };
     use crate::{BadExponent, Error, ErrorReason, InvalidProof, InvalidProofReason};
 
@@ -182,14 +185,18 @@ pub mod interactive {
         if data.n.is_even() {
             return Err(InvalidProofReason::ModulusIsEven.into());
         }
-        {
+        fail_if_ne(
+            InvalidProofReason::EqualityCheck(1),
+            &data.n.gcd_ref(&commitment.w).complete(),
+            Integer::ONE,
+        )?;
+
+        for (point, y) in proof.points.iter().zip(challenge.ys.iter()) {
             fail_if_ne(
-                InvalidProofReason::EqualityCheck(1),
-                &(data.n.clone()).gcd_ref(&commitment.w).complete(),
+                InvalidProofReason::EqualityCheck(2),
+                &y.gcd_ref(&data.n).complete(),
                 Integer::ONE,
             )?;
-        }
-        for (point, y) in proof.points.iter().zip(challenge.ys.iter()) {
             if Integer::from(
                 point
                     .z
@@ -226,10 +233,7 @@ pub mod interactive {
         Data { ref n }: &Data,
         rng: &mut R,
     ) -> Challenge<M> {
-        let ys = [(); M].map(|()| {
-            n.random_below_ref(&mut fast_paillier::utils::external_rand(rng))
-                .into()
-        });
+        let ys = [(); M].map(|()| Integer::gen_invertible(n, rng));
         Challenge { ys }
     }
 }
@@ -283,14 +287,8 @@ pub mod non_interactive {
             commitment,
         });
         let mut rng = rand_hash::HashRng::<D, _>::from_seed(seed);
-        // since we can't use Default and Integer isn't copy, we initialize
-        // like this
-        let ys = [(); M].map(|()| {
-            data.n
-                .random_below_ref(&mut fast_paillier::utils::external_rand(&mut rng))
-                .into()
-        });
-        Challenge { ys }
+
+        super::interactive::challenge(data, &mut rng)
     }
 }
 

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -126,7 +126,7 @@ pub mod interactive {
     use crate::{
         common::{
             fail_if_ne,
-            sqrt::{blum_sqrt, find_residue, sample_neg_jacobi},
+            sqrt::{blum_sqrt, find_residue, sample_invertible_with_neg_jacobi},
         },
         IntegerExt,
     };
@@ -137,7 +137,7 @@ pub mod interactive {
     /// Create random commitment
     pub fn commit<R: RngCore>(Data { ref n }: &Data, rng: &mut R) -> Commitment {
         Commitment {
-            w: sample_neg_jacobi(n, rng),
+            w: sample_invertible_with_neg_jacobi(n, rng),
         }
     }
 

--- a/spec/main.tex
+++ b/spec/main.tex
@@ -884,10 +884,10 @@ the output is undefined.
 \begin{inlineAlgorithm}
 \algoName{$\commit{mod}(N) \to w$}
 \algoInputs{public key $N \in \Z$}
-\algoOutputs{$w \in \Z_N$}
+\algoOutputs{$w \in \Z^*_N$}
 \begin{algorithmic}[1]
-\State Sample $w \gets \Z_N$ with Jacobi symbol $\left( \frac{w}{N} \right) = -1$
-\Comment{\parbox[t]{.4\linewidth}{can be done with rejection sampling: sample $w \gets \Z_N$, output $w$ if $\left( \frac{w}{N} \right) = -1$, repeat otherwise}}
+\State Sample $w \gets \Z^*_N$ with Jacobi symbol $\left( \frac{w}{N} \right) = -1$
+\Comment{\parbox[t]{.4\linewidth}{can be done with rejection sampling: sample $w \gets \Z^*_N$, output $w$ if $\left( \frac{w}{N} \right) = -1$, repeat otherwise}}
 \State \Return $w$
 \end{algorithmic}
 \end{inlineAlgorithm}
@@ -900,10 +900,10 @@ the output is undefined.
     \item public key $N \in \Z$
 }
 \algoOutputs{
-    $\vec y \in \Z_N^m$
+    $\vec y \in (\Z^*_N)^m$
 }
 \begin{algorithmic}[1]
-\State Sample $y_i \gets \Z_N$ for $i \in [m]$
+\State Sample $y_i \gets \Z^*_N$ for $i \in [m]$
 \State \Return $\vec y = \{y_i\}_{i\in[m]}$
 \end{algorithmic}
 \end{inlineAlgorithm}
@@ -920,14 +920,14 @@ the output is undefined.
 
     {\bf Note:} $p, q$ are assumed to be valid, so the implementation does not need to verify their correctness. In the protocol, it's the prover who generates the primes using appropriate procedure. If invalid $p, q$ are given, then resulting proof is invalid.
 }
-\algoOutputs{$\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Z, \Z, \Z)\}^m$}
+\algoOutputs{$\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Bit, \Bit, \Z)\}^m$}
 \begin{algorithmic}[1]
 \State $N' = N^{-1} \bmod \phi(N)$
 \For{$i \in [m]$}
     \State $(a_i, b_i, y'_i) = \fn{find\_residue}(y_i, w, p, q, N)$
     \State $x_i = \fn{blum\_sqrt}(\fn{blum\_sqrt}(y'_i, p, q, N), p, q, N)$
         \Comment{\parbox[t]{.3\linewidth}{$x_i$ is principal 4th root of $y'_i$ modulo $N$}}
-    \State $z_i = y_i^{N_i} \bmod N$
+    \State $z_i = y_i^{N'} \bmod N$
 \EndFor
 \State \Return $\{(x_i, a_i, b_i, z_i)\}_{i \in [m]}$
 \end{algorithmic}
@@ -939,15 +939,20 @@ the output is undefined.
 \algoInputsList{
     \item security level $L = (m, \dots)$,
     \item public data $N \in \Z$,
-    \item commitment $w \in \Z$,
-    \item challenge $\{y_i\}_{i\in[m]} \in \Z^m$,
-    \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Z, \Z, \Z)\}^m$
+    \item commitment $w \in \Z^*_N$,
+    \item challenge $\{y_i\}_{i\in[m]} \in (\Z^*_N)^m$,
+    \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Bit, \Bit, \Z)\}^m$
 }
 \algoOutputs{aborts if proof is invalid}
 \begin{algorithmic}[1]
-\State Assert that $N$ is odd non-prime
+\State $N \? = 1 \bmod 2$
+\State $\isprime(N) \? = \mathtt{false}$
+\State $\gcd(w, N) \? = 1$
+\Statex
 \For{$i \in [m]$}
+    \State $y_i \? \in \Z^*_N$
     \State $z_i^N \? = y_i \bmod N$
+    \State $(a_i, b_i) \? \in \Bit^2$
     \State $x_i^4 \? = (-1)^{a_i}w^{b_i}y_i \bmod N$
 \EndFor
 \end{algorithmic}
@@ -971,14 +976,14 @@ the output is undefined.
     {\bf Note:} $p, q$ are assumed to be valid, so the implementation does not need to verify their correctness. In the protocol, it's the prover who generates the primes using appropriate procedure. If invalid $p, q$ are given, then resulting proof is invalid.
 }
 \algoOutputsList{
-    \item challenge $w \in \Z$,
-    \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Z, \Z, \Z)\}^m$
+    \item challenge $w \in \Z^*_N$,
+    \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Bit, \Bit, \Z)\}^m$
 }
 \begin{algorithmic}[1]
 \State $w \gets \commit{mod}(N)$
 \State $\{y_i\}_{i\in[m]} = \challengeni{mod}^L(\state, N, w)$
 \State $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} = \prove{mod}^L(N, \{y_i\}_{i\in[m]}, w; (p, q))$
-\State \Return $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]}$
+\State \Return $(w, \{(x_i, a_i, b_i, z_i)\}_{i\in[m]})$
 \end{algorithmic}
 \end{inlineAlgorithm}
 
@@ -991,8 +996,8 @@ the output is undefined.
     \item public data: $N \in \Z$,
     \item non-interactive proof:
         \begin{itemize}
-        \item challenge $w \in \Z$,
-        \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Z, \Z, \Z)\}^m$
+        \item challenge $w \in \Z^*_N$,
+        \item proof $\{(x_i, a_i, b_i, z_i)\}_{i\in[m]} \in \{(\Z, \Bit, \Bit, \Z)\}^m$
         \end{itemize}
 }
 \algoOutputs{aborts if proof is invalid}


### PR DESCRIPTION
Moved from #133 originally authored by @manel1874

Update Paillier-Blum Modulus ZK $\prod^{mod}$ as there is one extra verification, $gcd(w,N)=1$, in the new [cggmp24](https://eprint.iacr.org/2021/060.pdf) version.  

# Motivation

This is part of the ongoing effort to update the cggmp21 implementetion to the latest version. Changes required within the zkps:

### New protocols to be implemented:
- [x] `Discrete Log with El-Gamal commitment ZK` $\prod^{elog}$. #131 
- [x] `Range Proof with El-Gamal commitment ZK` $\prod^{enc-elg}$. #132 

### Protocols to be changed
- [x] `Paillier-Blum Modulus ZK` $\prod^{mod}$. This PR
- [x] `No Small Factor ZK` $\prod^{fac}$. #134 

### Protocols no longer used (to be deleted)
- [ ] `Paillier Encryption in Range ZK` $\prod^{enc}$