### PR TITLE
Fix sampling from wrong range 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cggmp21"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cggmp21-keygen",
  "digest",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "fast-paillier"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da6ffbfab3f6dc72b28f6f33dc76705c1a56b2c119680c936d239990beb5ae6"
+checksum = "d1108d991b54d8e3aa3eb155c07863306cbceafb713ab1ebcef085e19f3cb84c"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1527,6 +1527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,13 +2079,14 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.21.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8882d6fd62b334b72dcf5c79f7e6b529d6790322de14bb49339415266131b031"
+checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
  "libc",
+ "libm",
  "serde",
 ]
 

--- a/cggmp21/CHANGELOG.md
+++ b/cggmp21/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
+## v0.6.2
+* Update the protocol to match the spec
+
+[#145]: https://github.com/LFDT-Lockness/cggmp21/pull/145
+
 ## v0.6.1
 * Trusted dealer can generate shares at random or non-standard preimages [#137]
+
+[#137]: https://github.com/LFDT-Lockness/cggmp21/pull/137
 
 ## v0.6.0
 * Update `hd-wallet` dep to v0.6 [#120]

--- a/cggmp21/Cargo.toml
+++ b/cggmp21/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cggmp21"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "TSS ECDSA implementation based on CGGMP21 paper"

--- a/cggmp21/src/signing.rs
+++ b/cggmp21/src/signing.rs
@@ -826,8 +826,8 @@ where
 
         let r_ij = N_i.random_below_ref(&mut utils::external_rand(rng)).into();
         let hat_r_ij = N_i.random_below_ref(&mut utils::external_rand(rng)).into();
-        let s_ij = N_i.random_below_ref(&mut utils::external_rand(rng)).into();
-        let hat_s_ij = N_i.random_below_ref(&mut utils::external_rand(rng)).into();
+        let s_ij = N_j.random_below_ref(&mut utils::external_rand(rng)).into();
+        let hat_s_ij = N_j.random_below_ref(&mut utils::external_rand(rng)).into();
 
         let beta_ij = Integer::from_rng_pm(&J, rng);
         let hat_beta_ij = Integer::from_rng_pm(&J, rng);


### PR DESCRIPTION
There was sampling from $N_i$ whereas spec says to sample from $N_j$. That was passed undetected until we updated `fast-paillier` to reject $x \ge N$ when checking $x \in \mathbb{Z}^*_N$, which now makes the protocol randomly abort when $N_j < N_i$ and sampled $x  > N_j$.

Fixes #144 