### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This crate **does not** (currently) support:
 
 Our implementation has been audited by Kudelski. Report can be found [here][report].
 
+> About notion of threshold and non-threshold keys: originally, the CGGMP24 paper does not specify
+protocols for threshold t-out-of-n keys with arbitrary `t`, and only works with non-threshold
+n-out-of-n keys. We have added support for arbitrary threshold $2 \le t \le n$, however, we made
+it possible to opt out thresholdness so original CGGMP24 protocol can be carried out if needed.
+
 ## Running the protocol
 
 ### Networking
@@ -228,7 +233,13 @@ However, you may opt for them by enabling `spof` feature, then you can use `trus
 for key import and `key_share::reconstruct_secret_key` for key export.
 
 ## Differences between the implementation and CGGMP24
-There are small differences in the implementation compared to the original paper [CGGMP24] (mostly typo fixes);
+[CGGMP24] only defines a non-threshold protocol. To support general thresholds,
+we defined our own CGGMP24-like key generation and threshold signing
+protocols. However, we keep both
+threshold and non-threshold versions of the protocols in the crate, so if you opt for the non-threshold
+protocol, you will be running the original protocol defined in the paper.
+
+There are other (small) differences in the implementation compared to the original paper (mostly typo fixes);
 they are all documented in [the spec].
 
 [CGGMP24]: https://ia.cr/2021/060

--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@
 
 <!-- TOC ENDS -->
 
-[CGGMP24] is a state-of-art ECDSA TSS protocol that supports 1-round signing (requires preprocessing),
-identifiable abort, provides two signing protocols (3+1 and 5+1 rounds with different complexity
-of abort identification) and key refresh protocol out of the box.
+[CGGMP24] is a state-of-art ECDSA TSS protocol that supports 1-round signing (requires 3 preprocessing rounds),
+identifiable abort, and a key refresh protocol.
 
 This crate implements:
 * Threshold (i.e., t-out-of-n) and non-threshold (i.e., n-out-of-n) key generation
 * (3+1)-round general threshold and non-threshold signing
 * Auxiliary info generation protocol
-* Key refresh for non-threshold keys
 * HD-wallets support based on [slip10] standard (compatible with [bip32]) \
   Requires `hd-wallets` feature
 
@@ -45,16 +43,10 @@ We also provide auxiliary tools like:
 * Trusted dealer (importing key into TSS)
 
 This crate **does not** (currently) support:
-* Key refresh for threshold keys (i.e., t-out-of-n)
+* Key refresh for both threshold (i.e., t-out-of-n) and non-threshold (i.e., n-out-of-n) keys
 * Identifiable abort
-* The (5+1)-round signing protocol
 
 Our implementation has been audited by Kudelski. Report can be found [here][report].
-
-> About notion of threshold and non-threshold keys: originally, CGGMP24 paper does not have support of
-arbitrary `t` and only works with non-threshold n-out-of-n keys. We have added support of arbitrary
-threshold $2 \le t \le n$, however, we made it possible to opt out thresholdness so original CGGMP24
-protocol can be carried out if needed.
 
 ## Running the protocol
 
@@ -236,13 +228,7 @@ However, you may opt for them by enabling `spof` feature, then you can use `trus
 for key import and `key_share::reconstruct_secret_key` for key export.
 
 ## Differences between the implementation and CGGMP24
-[CGGMP24] only defines a non-threshold protocol. To support general thresholds,
-we defined our own CGGMP24-like key generation and threshold signing
-protocols. However, we keep both
-threshold and non-threshold versions of the protocols in the crate, so if you opt for the non-threshold
-protocol, you will be running the original protocol defined in the paper.
-
-There are other (small) differences in the implementation compared to the original paper (mostly typo fixes);
+There are small differences in the implementation compared to the original paper [CGGMP24] (mostly typo fixes);
 they are all documented in [the spec].
 
 [CGGMP24]: https://ia.cr/2021/060

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -30,6 +30,11 @@
 //!
 //! Our implementation has been audited by Kudelski. Report can be found [here][report].
 //!
+//! > About notion of threshold and non-threshold keys: originally, the CGGMP24 paper does not specify
+//! protocols for threshold t-out-of-n keys with arbitrary `t`, and only works with non-threshold
+//! n-out-of-n keys. We have added support for arbitrary threshold $2 \le t \le n$, however, we made
+//! it possible to opt out thresholdness so original CGGMP24 protocol can be carried out if needed.
+//! 
 //! ## Running the protocol
 //!
 //! ### Networking
@@ -253,7 +258,13 @@
 //! for key import and [`key_share::reconstruct_secret_key`] for key export.
 //!
 //! ## Differences between the implementation and CGGMP24
-//! There are small differences in the implementation compared to the original paper [CGGMP24] (mostly typo fixes);
+//! [CGGMP24] only defines a non-threshold protocol. To support general thresholds,
+//! we defined our own CGGMP24-like key generation and threshold signing
+//! protocols. However, we keep both
+//! threshold and non-threshold versions of the protocols in the crate, so if you opt for the non-threshold
+//! protocol, you will be running the original protocol defined in the paper.
+//!
+//! There are other (small) differences in the implementation compared to the original paper (mostly typo fixes);
 //! they are all documented in [the spec].
 //!
 //! [CGGMP24]: https://ia.cr/2021/060

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -8,15 +8,13 @@
 //! <!-- TOC -->
 #![doc = include_str!("../docs/toc-cggmp24.md")]
 //!
-//! [CGGMP24] is a state-of-art ECDSA TSS protocol that supports 1-round signing (requires preprocessing),
-//! identifiable abort, provides two signing protocols (3+1 and 5+1 rounds with different complexity
-//! of abort identification) and key refresh protocol out of the box.
+//! [CGGMP24] is a state-of-art ECDSA TSS protocol that supports 1-round signing (requires 3 preprocessing rounds),
+//! identifiable abort, and a key refresh protocol.
 //!
 //! This crate implements:
 //! * Threshold (i.e., t-out-of-n) and non-threshold (i.e., n-out-of-n) key generation
 //! * (3+1)-round general threshold and non-threshold signing
 //! * Auxiliary info generation protocol
-//! * Key refresh for non-threshold keys
 //! * HD-wallets support based on [slip10] standard (compatible with [bip32]) \
 //!   Requires `hd-wallets` feature
 //!
@@ -27,16 +25,10 @@
 //! * [Trusted dealer](crate::trusted_dealer) (importing key into TSS)
 //!
 //! This crate **does not** (currently) support:
-//! * Key refresh for threshold keys (i.e., t-out-of-n)
+//! * Key refresh for both threshold (i.e., t-out-of-n) and non-threshold (i.e., n-out-of-n) keys
 //! * Identifiable abort
-//! * The (5+1)-round signing protocol
 //!
 //! Our implementation has been audited by Kudelski. Report can be found [here][report].
-//!
-//! > About notion of threshold and non-threshold keys: originally, CGGMP24 paper does not have support of
-//! arbitrary `t` and only works with non-threshold n-out-of-n keys. We have added support of arbitrary
-//! threshold $2 \le t \le n$, however, we made it possible to opt out thresholdness so original CGGMP24
-//! protocol can be carried out if needed.
 //!
 //! ## Running the protocol
 //!
@@ -261,13 +253,7 @@
 //! for key import and [`key_share::reconstruct_secret_key`] for key export.
 //!
 //! ## Differences between the implementation and CGGMP24
-//! [CGGMP24] only defines a non-threshold protocol. To support general thresholds,
-//! we defined our own CGGMP24-like key generation and threshold signing
-//! protocols. However, we keep both
-//! threshold and non-threshold versions of the protocols in the crate, so if you opt for the non-threshold
-//! protocol, you will be running the original protocol defined in the paper.
-//!
-//! There are other (small) differences in the implementation compared to the original paper (mostly typo fixes);
+//! There are small differences in the implementation compared to the original paper [CGGMP24] (mostly typo fixes);
 //! they are all documented in [the spec].
 //!
 //! [CGGMP24]: https://ia.cr/2021/060

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -34,7 +34,7 @@
 //! protocols for threshold t-out-of-n keys with arbitrary `t`, and only works with non-threshold
 //! n-out-of-n keys. We have added support for arbitrary threshold $2 \le t \le n$, however, we made
 //! it possible to opt out thresholdness so original CGGMP24 protocol can be carried out if needed.
-//! 
+//!
 //! ## Running the protocol
 //!
 //! ### Networking


### PR DESCRIPTION
### Update README.md for CGGMP24

This update addresses one of the TODOs in the Issue [CGGMP24 TODOs](https://github.com/LFDT-Lockness/cggmp21/issues/151#issue-3313573246).

### Changes

- Removed mentions to the **5 + 1 signing protocol**.
- Update the mentions to **key refresh** : 
   - remove it from [this crate implements](https://github.com/LFDT-Lockness/cggmp21/blob/8cd2b4da5759a6fea90fbb7698715fd779a8e9eb/README.md?plain=1#L37)
   - added it under [This crate **does not** (currently) support](https://github.com/LFDT-Lockness/cggmp21/blob/8cd2b4da5759a6fea90fbb7698715fd779a8e9eb/README.md?plain=1#L47)
   - Note that CGGMP24 still supports key refresh.
- As [CGGMP24](https://eprint.iacr.org/2021/060.pdf) now **supports threshold (t-out-of-n) keys** (see Section F.1), removed all statements claiming that it was not supported in CGGMP24