### PR TITLE
Refactor Non-Interactive Proofs to use type NiProof

### DIFF
--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -93,7 +93,7 @@ pub struct MsgRound2<L: SecurityLevel> {
 pub struct MsgRound3 {
     /// $\psi_i$
     // this should be L::M instead, but no rustc support yet
-    pub mod_proof: π_mod::non_interactive::Proof<{ crate::security_level::M }>,
+    pub mod_proof: π_mod::NiProof<{ crate::security_level::M }>,
     /// $\phi_i^j$
     pub fac_proof: π_fac::Proof,
 }

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -2,7 +2,7 @@ use digest::Digest;
 use futures::SinkExt;
 use paillier_zk::{
     no_small_factor::non_interactive as π_fac,
-    paillier_blum_modulus::{self as π_mod},
+    paillier_blum_modulus as π_mod,
     rug::{Complete, Integer},
 };
 use rand_core::{CryptoRng, RngCore};
@@ -93,7 +93,7 @@ pub struct MsgRound2<L: SecurityLevel> {
 pub struct MsgRound3 {
     /// $\psi_i$
     // this should be L::M instead, but no rustc support yet
-    pub mod_proof: π_mod::NiProof<{ crate::security_level::M }>,
+    pub mod_proof: π_mod::non_interactive::Proof<{ crate::security_level::M }>,
     /// $\phi_i^j$
     pub fac_proof: π_fac::Proof,
 }
@@ -435,7 +435,6 @@ where
         &decommitments,
         &shares_msg_b,
         |j, decommitment, proof_msg| {
-            let niproof = &proof_msg.mod_proof;
             π_mod::non_interactive::verify::<{ crate::security_level::M }, D>(
                 &unambiguous::ProofMod {
                     sid,
@@ -443,7 +442,7 @@ where
                     prover: j,
                 },
                 π_mod::Data { n: &decommitment.N },
-                niproof,
+                &proof_msg.mod_proof,
             )
             .is_err()
         },

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -2,7 +2,7 @@ use digest::Digest;
 use futures::SinkExt;
 use paillier_zk::{
     no_small_factor::non_interactive as π_fac,
-    paillier_blum_modulus as π_mod,
+    paillier_blum_modulus::{self as π_mod},
     rug::{Complete, Integer},
 };
 use rand_core::{CryptoRng, RngCore};
@@ -93,10 +93,7 @@ pub struct MsgRound2<L: SecurityLevel> {
 pub struct MsgRound3 {
     /// $\psi_i$
     // this should be L::M instead, but no rustc support yet
-    pub mod_proof: (
-        π_mod::Commitment,
-        π_mod::Proof<{ crate::security_level::M }>,
-    ),
+    pub mod_proof: π_mod::NiProof<{ crate::security_level::M }>,
     /// $\phi_i^j$
     pub fac_proof: π_fac::Proof,
 }
@@ -438,7 +435,7 @@ where
         &decommitments,
         &shares_msg_b,
         |j, decommitment, proof_msg| {
-            let (comm, proof) = &proof_msg.mod_proof;
+            let niproof = &proof_msg.mod_proof;
             π_mod::non_interactive::verify::<{ crate::security_level::M }, D>(
                 &unambiguous::ProofMod {
                     sid,
@@ -446,8 +443,7 @@ where
                     prover: j,
                 },
                 π_mod::Data { n: &decommitment.N },
-                comm,
-                proof,
+                niproof,
             )
             .is_err()
         },

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -28,7 +28,7 @@
 //! let data = p::Data { n: &n };
 //! let pdata = p::PrivateData { p: &p, q: &q };
 //!
-//! let niproof =
+//! let proof =
 //!     p::non_interactive::prove::<{SECURITY}, sha2::Sha256>(
 //!         &shared_state,
 //!         data,
@@ -38,18 +38,18 @@
 //!
 //! // 2. P sends `data, commitment, proof` to the verifier V
 //!
-//! # fn send(_: &p::Data, _: &p::NiProof<{SECURITY}>) { }
-//! send(&data, &niproof);
+//! # fn send(_: &p::Data, _: &p::non_interactive::Proof<{SECURITY}>) { }
+//! send(&data, &proof);
 //!
 //! // 3. V receives and verifies the proof:
 //!
-//! # let recv = || (data, niproof);
-//! let (data, niproof) = recv();
+//! # let recv = || (data, proof);
+//! let (data, proof) = recv();
 //!
 //! p::non_interactive::verify::<{SECURITY}, sha2::Sha256>(
 //!     &shared_state,
 //!     data,
-//!     &niproof,
+//!     &proof,
 //! )?;
 //! # Ok(()) }
 //! ```
@@ -112,14 +112,6 @@ pub struct Proof<const M: usize> {
         serde(with = "serde_with::As::<[serde_with::Same; M]>")
     )]
     pub points: [ProofPoint; M],
-}
-
-/// The Non-interactive ZK proof. Combines commitment and proof
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct NiProof<const M: usize> {
-    pub commitment: Commitment,
-    pub proof: Proof<M>,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
@@ -248,7 +240,17 @@ pub mod non_interactive {
 
     use crate::{Error, InvalidProof};
 
-    use super::{Challenge, Commitment, Data, NiProof, PrivateData};
+    use super::{Challenge, Commitment, Data, PrivateData};
+
+    #[cfg(feature = "serde")]
+    use serde::{Deserialize, Serialize};
+    /// The Non-interactive ZK proof. Combines commitment and proof.
+    #[derive(Debug, Clone)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Proof<const M: usize> {
+        pub commitment: Commitment,
+        pub proof: super::Proof<M>,
+    }
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving determenistic challenge.
@@ -259,23 +261,21 @@ pub mod non_interactive {
         data: Data,
         pdata: PrivateData,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<NiProof<M>, Error> {
+    ) -> Result<Proof<M>, Error> {
         let commitment = super::interactive::commit(data, rng);
         let challenge = challenge::<M, D>(shared_state, data, &commitment);
         let proof = super::interactive::prove(data, pdata, &commitment, &challenge)?;
-        Ok(NiProof { commitment, proof })
+        Ok(Proof { commitment, proof })
     }
 
     /// Verify the proof, deriving challenge independently from same data
     pub fn verify<const M: usize, D: Digest>(
         shared_state: &impl udigest::Digestable,
         data: Data,
-        niproof: &NiProof<M>,
+        proof: &Proof<M>,
     ) -> Result<(), InvalidProof> {
-        let commitment = &niproof.commitment;
-        let proof = &niproof.proof;
-        let challenge = challenge::<M, D>(shared_state, data, commitment);
-        super::interactive::verify(data, commitment, &challenge, proof)
+        let challenge = challenge::<M, D>(shared_state, data, &proof.commitment);
+        super::interactive::verify(data, &proof.commitment, &challenge, &proof.proof)
     }
 
     /// Deterministically compute challenge based on prior known values in protocol
@@ -313,9 +313,9 @@ mod test {
         let data = super::Data { n: &n };
         let pdata = super::PrivateData { p: &p, q: &q };
         let shared_state = "shared state";
-        let niproof =
+        let proof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();
-        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &niproof);
+        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &proof);
         match r {
             Ok(()) => (),
             Err(e) => panic!("{e:?}"),

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -28,7 +28,7 @@
 //! let data = p::Data { n: &n };
 //! let pdata = p::PrivateData { p: &p, q: &q };
 //!
-//! let (commitment, proof) =
+//! let niproof =
 //!     p::non_interactive::prove::<{SECURITY}, sha2::Sha256>(
 //!         &shared_state,
 //!         data,
@@ -38,19 +38,18 @@
 //!
 //! // 2. P sends `data, commitment, proof` to the verifier V
 //!
-//! # fn send(_: &p::Data, _: &p::Commitment, _: &p::Proof<{SECURITY}>) { }
-//! send(&data, &commitment, &proof);
+//! # fn send(_: &p::Data, _: &p::NiProof<{SECURITY}>) { }
+//! send(&data, &niproof);
 //!
 //! // 3. V receives and verifies the proof:
 //!
-//! # let recv = || (data, commitment, proof);
-//! let (data, commitment, proof) = recv();
+//! # let recv = || (data, niproof);
+//! let (data, niproof) = recv();
 //!
 //! p::non_interactive::verify::<{SECURITY}, sha2::Sha256>(
 //!     &shared_state,
 //!     data,
-//!     &commitment,
-//!     &proof,
+//!     &niproof,
 //! )?;
 //! # Ok(()) }
 //! ```
@@ -113,6 +112,14 @@ pub struct Proof<const M: usize> {
         serde(with = "serde_with::As::<[serde_with::Same; M]>")
     )]
     pub points: [ProofPoint; M],
+}
+
+/// The Non-interactive ZK proof. Combines commitment and proof
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NiProof<const M: usize> {
+    pub commitment: Commitment,
+    pub proof: Proof<M>,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
@@ -241,7 +248,7 @@ pub mod non_interactive {
 
     use crate::{Error, InvalidProof};
 
-    use super::{Challenge, Commitment, Data, PrivateData, Proof};
+    use super::{Challenge, Commitment, Data, NiProof, PrivateData};
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving determenistic challenge.
@@ -252,20 +259,21 @@ pub mod non_interactive {
         data: Data,
         pdata: PrivateData,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<(Commitment, Proof<M>), Error> {
+    ) -> Result<NiProof<M>, Error> {
         let commitment = super::interactive::commit(data, rng);
         let challenge = challenge::<M, D>(shared_state, data, &commitment);
         let proof = super::interactive::prove(data, pdata, &commitment, &challenge)?;
-        Ok((commitment, proof))
+        Ok(NiProof { commitment, proof })
     }
 
     /// Verify the proof, deriving challenge independently from same data
     pub fn verify<const M: usize, D: Digest>(
         shared_state: &impl udigest::Digestable,
         data: Data,
-        commitment: &Commitment,
-        proof: &Proof<M>,
+        niproof: &NiProof<M>,
     ) -> Result<(), InvalidProof> {
+        let commitment = &niproof.commitment;
+        let proof = &niproof.proof;
         let challenge = challenge::<M, D>(shared_state, data, commitment);
         super::interactive::verify(data, commitment, &challenge, proof)
     }
@@ -305,9 +313,9 @@ mod test {
         let data = super::Data { n: &n };
         let pdata = super::PrivateData { p: &p, q: &q };
         let shared_state = "shared state";
-        let (commitment, proof) =
+        let niproof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();
-        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &commitment, &proof);
+        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &niproof);
         match r {
             Ok(()) => (),
             Err(e) => panic!("{e:?}"),
@@ -329,9 +337,9 @@ mod test {
         let data = super::Data { n: &n };
         let pdata = super::PrivateData { p: &p, q: &q };
         let shared_state = "shared state";
-        let (commitment, proof) =
+        let niproof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();
-        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &commitment, &proof);
+        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &niproof);
         if r.is_ok() {
             panic!("proof should not pass");
         }

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -38,7 +38,7 @@
 //!
 //! // 2. P sends `data, commitment, proof` to the verifier V
 //!
-//! # fn send(_: &p::Data, _: &p::non_interactive::Proof<{SECURITY}>) { }
+//! # fn send(_: &p::Data, _: &p::NiProof<{SECURITY}>) { }
 //! send(&data, &proof);
 //!
 //! // 3. V receives and verifies the proof:
@@ -101,8 +101,8 @@ pub struct ProofPoint {
     pub z: Integer,
 }
 
-/// The ZK proof. Computed by [`interactive::prove`] or
-/// [`non_interactive::prove`]. Consists of M proofs for each challenge
+/// The ZK proof. Computed by [`interactive::prove`].
+/// Consists of M proofs for each challenge
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Proof<const M: usize> {
@@ -112,6 +112,15 @@ pub struct Proof<const M: usize> {
         serde(with = "serde_with::As::<[serde_with::Same; M]>")
     )]
     pub points: [ProofPoint; M],
+}
+
+/// The non-interactive ZK proof. Computed by [`non_interactive::prove`].
+/// Combines commitment and proof.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NiProof<const M: usize> {
+    pub commitment: Commitment,
+    pub proof: Proof<M>,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
@@ -240,17 +249,7 @@ pub mod non_interactive {
 
     use crate::{Error, InvalidProof};
 
-    use super::{Challenge, Commitment, Data, PrivateData};
-
-    #[cfg(feature = "serde")]
-    use serde::{Deserialize, Serialize};
-    /// The Non-interactive ZK proof. Combines commitment and proof.
-    #[derive(Debug, Clone)]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct Proof<const M: usize> {
-        pub commitment: Commitment,
-        pub proof: super::Proof<M>,
-    }
+    use super::{Challenge, Commitment, Data, NiProof, PrivateData};
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving determenistic challenge.
@@ -261,18 +260,18 @@ pub mod non_interactive {
         data: Data,
         pdata: PrivateData,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<Proof<M>, Error> {
+    ) -> Result<NiProof<M>, Error> {
         let commitment = super::interactive::commit(data, rng);
         let challenge = challenge::<M, D>(shared_state, data, &commitment);
         let proof = super::interactive::prove(data, pdata, &commitment, &challenge)?;
-        Ok(Proof { commitment, proof })
+        Ok(NiProof { commitment, proof })
     }
 
     /// Verify the proof, deriving challenge independently from same data
     pub fn verify<const M: usize, D: Digest>(
         shared_state: &impl udigest::Digestable,
         data: Data,
-        proof: &Proof<M>,
+        proof: &NiProof<M>,
     ) -> Result<(), InvalidProof> {
         let challenge = challenge::<M, D>(shared_state, data, &proof.commitment);
         super::interactive::verify(data, &proof.commitment, &challenge, &proof.proof)
@@ -337,9 +336,9 @@ mod test {
         let data = super::Data { n: &n };
         let pdata = super::PrivateData { p: &p, q: &q };
         let shared_state = "shared state";
-        let niproof =
+        let proof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();
-        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &niproof);
+        let r = super::non_interactive::verify::<65, D>(&shared_state, data, &proof);
         if r.is_ok() {
             panic!("proof should not pass");
         }


### PR DESCRIPTION
This PR partially addresses one of the TODOs in [CGGMP24 TODOs](https://github.com/LFDT-Lockness/cggmp21/issues/151#issue-3313573246):

Refactoring Non Interactive Proofs such that they accept `type NiProof = (Commitment, Proof)`

Currently, this change has been applied to the Non-Interactive ZK-proof of Paillier-Blum modulus.




