### PR TITLE
Add NiProof struct in zk dlog with el gamal commit

### DIFF
--- a/cggmp24/src/signing.rs
+++ b/cggmp24/src/signing.rs
@@ -216,7 +216,7 @@ pub mod msg {
         /// $\hat F_{j,i}$
         pub hat_F: fast_paillier::Ciphertext,
         /// $\psi_i$
-        pub tilde_psi: (pi_elog::Commitment<E>, pi_elog::Proof<E>),
+        pub tilde_psi: pi_elog::NiProof<E>,
         /// $\psi_{j,i}$
         pub psi_j: (pi_aff::Commitment<E>, pi_aff::Proof),
         /// $\hat \psi_{j,i}$
@@ -234,7 +234,7 @@ pub mod msg {
         /// $\Delta_i$
         pub Delta: Point<E>,
         /// $\psi'_i$
-        pub psi_prime: (pi_elog::Commitment<E>, pi_elog::Proof<E>),
+        pub psi_prime: pi_elog::NiProof<E>,
     }
 
     /// Message from round 4
@@ -1142,8 +1142,7 @@ where
                     y: &msg.Gamma,
                     h: &Point::generator().to_point(),
                 },
-                &msg.tilde_psi.0,
-                &msg.tilde_psi.1,
+                &msg.tilde_psi,
             )
             .err();
 
@@ -1296,8 +1295,7 @@ where
                     y: &msg_j.Delta,
                     h: &Gamma,
                 },
-                &msg_j.psi_prime.0,
-                &msg_j.psi_prime.1,
+                &msg_j.psi_prime,
             )
             .err()
         });

--- a/paillier-zk/src/dlog_with_el_gamal_commitment.rs
+++ b/paillier-zk/src/dlog_with_el_gamal_commitment.rs
@@ -44,7 +44,7 @@
 //! };
 //!
 //! // Generate non-interactive proof
-//! let (commitment, proof) =
+//! let proof =
 //!     p::non_interactive::prove::<E, sha2::Sha256>(
 //!         &shared_state,
 //!         data,
@@ -55,17 +55,16 @@
 //! // Proof and the data are sent to the verifier
 //!
 //! # use generic_ec::Curve;
-//! # fn send<E: Curve>(_: &p::Data<E>, _: &p::Commitment<E>, _: &p::Proof<E>) {  }
-//! send(&data, &commitment, &proof);
+//! # fn send<E: Curve>(_: &p::Data<E>, _: &p::NiProof<E>) {  }
+//! send(&data, &proof);
 //!
 //! // Verifier receives the data and the proof and verifies them
 //!
-//! # let recv = || (data, commitment, proof);
-//! let (data, commitment, proof) = recv();
+//! # let recv = || (data, proof);
+//! let (data, proof) = recv();
 //! let r = p::non_interactive::verify::<E, sha2::Sha256>(
 //!     &shared_state,
 //!     data,
-//!     &commitment,
 //!     &proof,
 //! )?;
 //! #
@@ -128,13 +127,20 @@ pub struct PrivateCommitment<E: Curve> {
 /// [`non_interactive::challenge`] or randomly by [`interactive::challenge`]
 pub type Challenge<E> = Scalar<E>;
 
-/// The ZK proof. Computed by [`interactive::prove`] or
-/// [`non_interactive::prove`]
+/// The ZK proof. Computed by [`interactive::prove`].
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(bound = ""))]
 pub struct Proof<E: Curve> {
     pub z: Scalar<E>,
     pub u: Scalar<E>,
+}
+
+/// The non-interactive ZK proof. Computed by [`non_interactive::prove`].
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(bound = ""))]
+pub struct NiProof<E: Curve> {
+    pub commitment: Commitment<E>,
+    pub proof: Proof<E>,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
@@ -218,7 +224,7 @@ pub mod non_interactive {
 
     use crate::{Error, InvalidProof};
 
-    use super::{Challenge, Commitment, Data, PrivateData, Proof};
+    use super::{Challenge, Commitment, Data, NiProof, PrivateData};
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving deterministic challenge.
@@ -229,22 +235,21 @@ pub mod non_interactive {
         data: Data<E>,
         pdata: PrivateData<E>,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<(Commitment<E>, Proof<E>), Error> {
-        let (comm, pcomm) = super::interactive::commit(data, rng)?;
-        let challenge = challenge::<E, D>(shared_state, data, &comm);
+    ) -> Result<NiProof<E>, Error> {
+        let (commitment, pcomm) = super::interactive::commit(data, rng)?;
+        let challenge = challenge::<E, D>(shared_state, data, &commitment);
         let proof = super::interactive::prove::<E>(pdata, &pcomm, &challenge)?;
-        Ok((comm, proof))
+        Ok(NiProof { commitment, proof })
     }
 
     /// Verify the proof, deriving challenge independently from same data
     pub fn verify<E: Curve, D: Digest>(
         shared_state: &impl udigest::Digestable,
         data: Data<E>,
-        commitment: &Commitment<E>,
-        proof: &Proof<E>,
+        proof: &NiProof<E>,
     ) -> Result<(), InvalidProof> {
-        let challenge = challenge::<E, D>(shared_state, data, commitment);
-        super::interactive::verify::<E>(data, commitment, &challenge, proof)
+        let challenge = challenge::<E, D>(shared_state, data, &proof.commitment);
+        super::interactive::verify::<E>(data, &proof.commitment, &challenge, &proof.proof)
     }
 
     /// Deterministically compute challenge based on prior known values in protocol
@@ -278,9 +283,8 @@ mod test {
     ) -> Result<(), crate::common::InvalidProof> {
         let shared_state = "shared state";
 
-        let (commitment, proof) =
-            super::non_interactive::prove::<E, D>(&shared_state, data, pdata, rng).unwrap();
-        super::non_interactive::verify::<E, D>(&shared_state, data, &commitment, &proof)
+        let proof = super::non_interactive::prove::<E, D>(&shared_state, data, pdata, rng).unwrap();
+        super::non_interactive::verify::<E, D>(&shared_state, data, &proof)
     }
 
     fn passing_test<E: Curve, D: Digest>() {


### PR DESCRIPTION
Similar to PR [#154](https://github.com/LFDT-Lockness/cggmp21/pull/154#issue-3356180215), this PR partially addresses one of the TODOs from [CGGMP24TODOs](https://github.com/LFDT-Lockness/cggmp21/issues/151#issue-3313573246): Refactor NI proofs so they accept NiProof `struct NiProof = (Commitment, Proof)`.

This change was applied to the ZK-proof of discrete log with El-Gamal commitment.

I still call `proof` for some variables whose type is `NiProof`. If you prefer, I can change those variables name to `ni_proof`.


