### PR TITLE
Add NiProof struct in zk enc: paillier encryption in range

### DIFF
--- a/paillier-zk/src/paillier_encryption_in_range.rs
+++ b/paillier-zk/src/paillier_encryption_in_range.rs
@@ -52,7 +52,7 @@
 //! // 3. Prover computes a non-interactive proof that plaintext is at most 1024 bits:
 //!
 //! let data = p::Data { key, ciphertext: &ciphertext };
-//! let (commitment, proof) = p::non_interactive::prove::<sha2::Sha256>(
+//! let proof = p::non_interactive::prove::<sha2::Sha256>(
 //!     &shared_state,
 //!     &aux,
 //!     data,
@@ -66,18 +66,17 @@
 //!
 //! // 4. Prover sends this data to verifier
 //!
-//! # fn send(_: &p::Data, _: &p::Commitment, _: &p::Proof) {  }
-//! send(&data, &commitment, &proof);
+//! # fn send(_: &p::Data, _: &p::NiProof) {  }
+//! send(&data, &proof);
 //!
 //! // 5. Verifier receives the data and the proof and verifies it
 //!
-//! # let recv = || (data, commitment, proof);
-//! let (data, commitment, proof) = recv();
+//! # let recv = || (data, proof);
+//! let (data, proof) = recv();
 //! p::non_interactive::verify::<sha2::Sha256>(
 //!     &shared_state,
 //!     &aux,
 //!     data,
-//!     &commitment,
 //!     &security,
 //!     &proof,
 //! );
@@ -157,14 +156,22 @@ pub struct PrivateCommitment {
 pub type Challenge = Integer;
 
 // As described in cggmp24 at page 33
-/// The ZK proof. Computed by [`interactive::prove`] or
-/// [`non_interactive::prove`]
+/// The ZK proof. Computed by [`interactive::prove`].
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Proof {
     pub z1: Integer,
     pub z2: Integer,
     pub z3: Integer,
+}
+
+/// The non-interactive ZK proof. Computed by [`non_interactive::prove`].
+/// Combines commitment and proof.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NiProof {
+    pub commitment: Commitment,
+    pub proof: Proof,
 }
 
 /// The interactive version of the ZK proof. Should be completed in 3 rounds:
@@ -301,7 +308,7 @@ pub mod non_interactive {
 
     use crate::{Error, InvalidProof};
 
-    use super::{Aux, Challenge, Commitment, Data, PrivateData, Proof, SecurityParams};
+    use super::{Aux, Challenge, Commitment, Data, NiProof, PrivateData, SecurityParams};
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving determenistic challenge.
@@ -314,11 +321,11 @@ pub mod non_interactive {
         pdata: PrivateData,
         security: &SecurityParams,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<(Commitment, Proof), Error> {
-        let (comm, pcomm) = super::interactive::commit(aux, data, pdata, security, rng)?;
-        let challenge = challenge::<D>(shared_state, aux, data, &comm, security);
+    ) -> Result<NiProof, Error> {
+        let (commitment, pcomm) = super::interactive::commit(aux, data, pdata, security, rng)?;
+        let challenge = challenge::<D>(shared_state, aux, data, &commitment, security);
         let proof = super::interactive::prove(data, pdata, &pcomm, &challenge)?;
-        Ok((comm, proof))
+        Ok(NiProof { commitment, proof })
     }
 
     /// Deterministically compute challenge based on prior known values in protocol
@@ -345,12 +352,18 @@ pub mod non_interactive {
         shared_state: &impl udigest::Digestable,
         aux: &Aux,
         data: Data,
-        commitment: &Commitment,
         security: &SecurityParams,
-        proof: &Proof,
+        proof: &NiProof,
     ) -> Result<(), InvalidProof> {
-        let challenge = challenge::<D>(shared_state, aux, data, commitment, security);
-        super::interactive::verify(aux, data, commitment, security, &challenge, proof)
+        let challenge = challenge::<D>(shared_state, aux, data, &proof.commitment, security);
+        super::interactive::verify(
+            aux,
+            data,
+            &proof.commitment,
+            security,
+            &challenge,
+            &proof.proof,
+        )
     }
 }
 
@@ -380,17 +393,10 @@ mod test {
         };
 
         let shared_state = "shared state";
-        let (commitment, proof) =
+        let proof =
             super::non_interactive::prove::<D>(&shared_state, &aux, data, pdata, &security, rng)
                 .unwrap();
-        super::non_interactive::verify::<D>(
-            &shared_state,
-            &aux,
-            data,
-            &commitment,
-            &security,
-            &proof,
-        )
+        super::non_interactive::verify::<D>(&shared_state, &aux, data, &security, &proof)
     }
 
     #[test]


### PR DESCRIPTION
Similar to PR #154, #155, this PR partially addresses one of the TODOs from #151 : Refactor NI proofs so they accept NiProof.

This change was applied to the ZK-proof of Paillier encryption in range
