### PR TITLE
Move NiProof struct to parent module in zk factoring of a RSA modulus

### DIFF
--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -1,8 +1,7 @@
 use digest::Digest;
 use futures::SinkExt;
 use paillier_zk::{
-    no_small_factor::non_interactive as π_fac,
-    paillier_blum_modulus as π_mod,
+    no_small_factor as π_fac, paillier_blum_modulus as π_mod,
     rug::{Complete, Integer},
 };
 use rand_core::{CryptoRng, RngCore};
@@ -95,7 +94,7 @@ pub struct MsgRound3 {
     // this should be L::M instead, but no rustc support yet
     pub mod_proof: π_mod::NiProof<{ crate::security_level::M }>,
     /// $\phi_i^j$
-    pub fac_proof: π_fac::Proof,
+    pub fac_proof: π_fac::NiProof,
 }
 
 /// Message from an optional round that enforces reliability check
@@ -380,7 +379,7 @@ where
         tracer.send_msg();
 
         tracer.stage("Compute П_fac (ψ'_i,j)");
-        let psi_prime = π_fac::prove::<D>(
+        let psi_prime = π_fac::non_interactive::prove::<D>(
             &unambiguous::ProofFac {
                 sid,
                 rho: rho_bytes.as_ref(),
@@ -459,7 +458,7 @@ where
         &decommitments,
         &shares_msg_b,
         |j, decommitment, proof_msg| {
-            π_fac::verify::<D>(
+            π_fac::non_interactive::verify::<D>(
                 &unambiguous::ProofFac {
                     sid,
                     rho: rho_bytes.as_ref(),

--- a/paillier-zk/src/no_small_factor.rs
+++ b/paillier-zk/src/no_small_factor.rs
@@ -12,7 +12,7 @@
 //!
 //! ```rust
 //! use rug::{Integer, Complete};
-//! use paillier_zk::no_small_factor::non_interactive as p;
+//! use paillier_zk::no_small_factor as p;
 //! # mod pregenerated {
 //! #     use super::*;
 //! #     paillier_zk::load_pregenerated_data!(
@@ -47,7 +47,7 @@
 //!
 //! // 2. Prover computes a non-interactive proof that both factors are large enough
 //!
-//! let proof = p::prove::<sha2::Sha256>(
+//! let proof = p::non_interactive::prove::<sha2::Sha256>(
 //!     &shared_state,
 //!     &aux,
 //!     data,
@@ -58,7 +58,7 @@
 //!
 //! // 4. Prover sends this data to verifier
 //!
-//! # fn send(_: &Integer, _: &p::Proof) {  }
+//! # fn send(_: &Integer, _: &p::NiProof) {  }
 //! send(data.n, &proof);
 //!
 //! // 5. Verifier receives the data and the proof and verifies it
@@ -70,7 +70,7 @@
 //!     n: &n,
 //!     n_root: &n_root,
 //! };
-//! p::verify::<sha2::Sha256>(&shared_state, &aux, data, &security, &proof)?;
+//! p::non_interactive::verify::<sha2::Sha256>(&shared_state, &aux, data, &security, &proof)?;
 //! # Ok(()) }
 //! ```
 //!
@@ -156,6 +156,15 @@ pub struct Proof {
     pub w1: Integer,
     pub w2: Integer,
     pub v: Integer,
+}
+
+/// The non-interactive ZK proof. Computed by [`non_interactive::prove`].
+/// Combines commitment and proof.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NiProof {
+    commitment: Commitment,
+    proof: Proof,
 }
 
 /// Interactive version of the proof
@@ -314,15 +323,7 @@ pub mod non_interactive {
 
     pub use crate::{Error, InvalidProof};
 
-    pub use super::{Aux, Challenge, Data, PrivateData, SecurityParams};
-
-    /// The ZK proof, computed by [`prove`]
-    #[derive(Debug, Clone)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Proof {
-        commitment: super::Commitment,
-        proof: super::Proof,
-    }
+    pub use super::{Aux, Challenge, Data, NiProof, PrivateData, SecurityParams};
 
     /// Compute proof for the given data, producing random commitment and
     /// deriving determenistic challenge.
@@ -335,11 +336,11 @@ pub mod non_interactive {
         pdata: PrivateData,
         security: &SecurityParams,
         rng: &mut impl rand_core::RngCore,
-    ) -> Result<Proof, Error> {
+    ) -> Result<NiProof, Error> {
         let (commitment, pcomm) = super::interactive::commit(aux, data, pdata, security, rng)?;
         let challenge = challenge::<D>(shared_state, aux, data, &commitment, security);
         let proof = super::interactive::prove(pdata, &pcomm, &challenge)?;
-        Ok(Proof { commitment, proof })
+        Ok(NiProof { commitment, proof })
     }
 
     /// Deterministically compute challenge based on prior known values in protocol
@@ -368,7 +369,7 @@ pub mod non_interactive {
         aux: &Aux,
         data: Data,
         security: &SecurityParams,
-        proof: &Proof,
+        proof: &NiProof,
     ) -> Result<(), InvalidProof> {
         let challenge = challenge::<D>(shared_state, aux, data, &proof.commitment, security);
         super::interactive::verify(


### PR DESCRIPTION
This PR partially addresses one of the TODOs from #151  : Refactor NI proofs so they accept NiProof.

The `Proof` struct for the Non_interactive ZK-proof for factoring of a RSA modulus was already define under the `non_interactive` module. I moved it to the parent module, rename it to `NiProof`, and update the code accordingly.

Together with PRs #154, #155, #156 , #157, and #158, this completes the Refactor of NI Proofs. (see #151).
