### PR TITLE
[Bugfix]: utils::sqrt no longer maps negative values to 1

### DIFF
--- a/cggmp24/src/key_refresh.rs
+++ b/cggmp24/src/key_refresh.rs
@@ -245,6 +245,8 @@ enum Bug {
     BuildMultiexpTables(#[source] crate::key_share::InvalidKeyShare),
     #[error("generate pedersen params")]
     GenPedersen(#[source] utils::GenPedersenError),
+    #[error("own modulus N is not positive")]
+    NegativeModulus,
 }
 
 /// Error indicating that protocol was aborted by malicious party

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -369,7 +369,7 @@ where
         l: L::ELL,
         epsilon: L::EPSILON,
     };
-    let n_sqrt = utils::sqrt(&N).expect("Own modulus N is always positive");
+    let n_sqrt = N.sqrt_ref().ok_or(Bug::NegativeModulus)?;
 
     // message to each party
     for (j, _, d) in decommitments.iter_indexed() {
@@ -456,7 +456,7 @@ where
         &decommitments,
         &shares_msg_b,
         |j, decommitment, proof_msg| {
-            let n_root = match utils::sqrt(&decommitment.N) {
+            let n_root = match decommitment.N.sqrt_ref() {
                 Some(root) => root,
                 None => return true,
             };

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -369,7 +369,7 @@ where
         l: L::ELL,
         epsilon: L::EPSILON,
     };
-    let n_sqrt = utils::sqrt(&N);
+    let n_sqrt = utils::sqrt(&N).expect("Own modulus N is always positive");
 
     // message to each party
     for (j, _, d) in decommitments.iter_indexed() {
@@ -456,6 +456,10 @@ where
         &decommitments,
         &shares_msg_b,
         |j, decommitment, proof_msg| {
+            let n_root = match utils::sqrt(&decommitment.N) {
+                Some(root) => root,
+                None => return true,
+            };
             π_fac::non_interactive::verify::<D>(
                 &unambiguous::ProofFac {
                     sid,
@@ -465,7 +469,7 @@ where
                 &phi_common_aux,
                 π_fac::Data {
                     n: &decommitment.N,
-                    n_root: &utils::sqrt(&decommitment.N),
+                    n_root: &n_root,
                 },
                 &π_fac_security,
                 &proof_msg.fac_proof,

--- a/cggmp24/src/utils.rs
+++ b/cggmp24/src/utils.rs
@@ -145,10 +145,10 @@ pub fn iter_peers(i: u16, n: u16) -> impl Iterator<Item = u16> {
     (0..n).filter(move |x| *x != i)
 }
 
-/// Binary search for rounded down square root. For non-positive numbers returns
-/// one
-pub fn sqrt(x: &Integer) -> Integer {
-    x.sqrt_ref().unwrap_or_else(Integer::one)
+/// Binary search for rounded down square root. Returns `None` for negative
+/// numbers
+pub fn sqrt(x: &Integer) -> Option<Integer> {
+    x.sqrt_ref()
 }
 
 /// Returns `[list[indexes[0]], list[indexes[1]], ..., list[indexes[n-1]]]`
@@ -236,23 +236,26 @@ mod test {
     #[test]
     fn test_sqrt() {
         use super::{sqrt, Integer};
-        assert_eq!(sqrt(&Integer::from(-5)), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(1)), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(2)), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(3)), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(4)), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(5)), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(6)), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(7)), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(8)), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(9)), Integer::from(3));
-        assert_eq!(sqrt(&(Integer::from(1) << 1024)), Integer::from(1) << 512);
+        assert_eq!(sqrt(&Integer::from(-5)), None);
+        assert_eq!(sqrt(&Integer::from(1)).unwrap(), Integer::from(1));
+        assert_eq!(sqrt(&Integer::from(2)).unwrap(), Integer::from(1));
+        assert_eq!(sqrt(&Integer::from(3)).unwrap(), Integer::from(1));
+        assert_eq!(sqrt(&Integer::from(4)).unwrap(), Integer::from(2));
+        assert_eq!(sqrt(&Integer::from(5)).unwrap(), Integer::from(2));
+        assert_eq!(sqrt(&Integer::from(6)).unwrap(), Integer::from(2));
+        assert_eq!(sqrt(&Integer::from(7)).unwrap(), Integer::from(2));
+        assert_eq!(sqrt(&Integer::from(8)).unwrap(), Integer::from(2));
+        assert_eq!(sqrt(&Integer::from(9)).unwrap(), Integer::from(3));
+        assert_eq!(
+            sqrt(&(Integer::from(1) << 1024)).unwrap(),
+            Integer::from(1) << 512
+        );
 
         let modulo = Integer::one() << 1024_u32;
         let mut rng = rand_dev::DevRng::new();
         for _ in 0..100 {
             let x = modulo.random_below_ref(&mut rng);
-            let root = sqrt(&x);
+            let root = sqrt(&x).unwrap();
             assert!(root.square_ref() <= x);
             let root = root + 1u8;
             assert!(root.square_ref() > x);

--- a/cggmp24/src/utils.rs
+++ b/cggmp24/src/utils.rs
@@ -145,12 +145,6 @@ pub fn iter_peers(i: u16, n: u16) -> impl Iterator<Item = u16> {
     (0..n).filter(move |x| *x != i)
 }
 
-/// Binary search for rounded down square root. Returns `None` for negative
-/// numbers
-pub fn sqrt(x: &Integer) -> Option<Integer> {
-    x.sqrt_ref()
-}
-
 /// Returns `[list[indexes[0]], list[indexes[1]], ..., list[indexes[n-1]]]`
 ///
 /// Result is `None` if any of `indexes[i]` is out of range of `list`
@@ -227,38 +221,6 @@ pub mod encoding {
             encoder: udigest::encoding::EncodeValue<B>,
         ) {
             encoder.encode_leaf_value(x.to_bytes_msf())
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn test_sqrt() {
-        use super::{sqrt, Integer};
-        assert_eq!(sqrt(&Integer::from(-5)), None);
-        assert_eq!(sqrt(&Integer::from(1)).unwrap(), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(2)).unwrap(), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(3)).unwrap(), Integer::from(1));
-        assert_eq!(sqrt(&Integer::from(4)).unwrap(), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(5)).unwrap(), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(6)).unwrap(), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(7)).unwrap(), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(8)).unwrap(), Integer::from(2));
-        assert_eq!(sqrt(&Integer::from(9)).unwrap(), Integer::from(3));
-        assert_eq!(
-            sqrt(&(Integer::from(1) << 1024)).unwrap(),
-            Integer::from(1) << 512
-        );
-
-        let modulo = Integer::one() << 1024_u32;
-        let mut rng = rand_dev::DevRng::new();
-        for _ in 0..100 {
-            let x = modulo.random_below_ref(&mut rng);
-            let root = sqrt(&x).unwrap();
-            assert!(root.square_ref() <= x);
-            let root = root + 1u8;
-            assert!(root.square_ref() > x);
         }
     }
 }


### PR DESCRIPTION
Fixes #57 

`utils::sqrt` used to return `1` when `Integer::sqrt_ref()` was `None` (negative input). That hid bad values and made ZK failures harder to trace and debug.

`sqrt` now returns `Option<Integer>` and delegates to `sqrt_ref()`. Call sites in aux key refresh use `.expect()` for our own modulus and treat `None` as a fault when verifying another party’s decommitment.

Tests updated accordingly.