### PR TITLE
feat: Implement CGGMP24 key share refresh protocol (#162)

### DIFF
--- a/cggmp24-keygen/src/key_refresh_non_threshold.rs
+++ b/cggmp24-keygen/src/key_refresh_non_threshold.rs
@@ -1,0 +1,487 @@
+//! Non-threshold (n-of-n) key share refresh protocol
+//!
+//! Implements the share-refresh portion of CGGMP24 Figure 7, omitting
+//! auxiliary data generation per [issue #162](https://github.com/LFDT-Lockness/cggmp21/issues/162).
+//!
+//! # Protocol
+//!
+//! All $n$ parties hold additive shares $x_i$ with $\sum x_i = x$.
+//! Each party $i$ samples random values $\{x_i^{(j)}\}_{j=1..n}$ such
+//! that $\sum_j x_i^{(j)} = 0$, creating a zero-sum contribution
+//! for each party. After commit-decommit and Feldman verification,
+//! each party computes:
+//! $$x_i' = x_i + \sum_j x_j^{(i)}$$
+//!
+//! The secret is preserved because:
+//! $$\sum_i x_i' = \sum_i x_i + \sum_i \sum_j x_j^{(i)} = x + \sum_j \sum_i x_j^{(i)} = x + \sum_j 0 = x$$
+//!
+//! # Rounds
+//!
+//! 1. **Commit**: hash commitment to public data and Schnorr commit
+//! 2. **(Optional) Reliability check**: echo-broadcast
+//! 3. **Decommit + P2P shares**: broadcast public commitments, unicast secret evaluations
+//! 4. **Prove**: Schnorr proof of knowledge of new secret share
+
+use alloc::vec::Vec;
+
+use digest::Digest;
+use generic_ec::{Curve, NonZero, Point, Scalar, SecretScalar};
+use generic_ec_zkp::schnorr_pok;
+use rand_core::{CryptoRng, RngCore};
+use round_based::{
+    rounds_router::simple_store::RoundInput, rounds_router::RoundsRouter, Delivery, Mpc, MpcParty,
+    Outgoing, ProtocolMessage, SinkExt,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::progress::Tracer;
+use crate::{
+    errors::IoError,
+    key_share::{CoreKeyShare, DirtyCoreKeyShare, DirtyKeyInfo, Validate},
+    security_level::SecurityLevel,
+    utils, ExecutionId,
+};
+
+use super::{KeyRefreshError, RefreshAborted, RefreshBug};
+
+macro_rules! prefixed {
+    ($name:tt) => {
+        concat!("dfns.cggmp24.key_refresh.non_threshold.", $name)
+    };
+}
+
+/// Message of non-threshold key refresh protocol
+#[derive(ProtocolMessage, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub enum Msg<E: Curve, L: SecurityLevel, D: Digest> {
+    /// Round 1: hash commitment
+    Round1(MsgRound1<D>),
+    /// Reliability check message (optional)
+    ReliabilityCheck(MsgReliabilityCheck<D>),
+    /// Round 2a: decommitment (broadcast)
+    Round2Broad(MsgRound2Broad<E, L>),
+    /// Round 2b: secret share (P2P unicast)
+    Round2Uni(MsgRound2Uni<E>),
+    /// Round 3: Schnorr proof
+    Round3(MsgRound3<E>),
+}
+
+/// Round 1 commitment message
+#[derive(Clone, Serialize, Deserialize, udigest::Digestable)]
+#[serde(bound = "")]
+#[udigest(bound = "")]
+#[udigest(tag = prefixed!("round1"))]
+pub struct MsgRound1<D: Digest> {
+    /// Hash commitment $V_i$
+    #[udigest(as_bytes)]
+    pub commitment: digest::Output<D>,
+}
+
+/// Round 2 broadcast: public commitments to zero-sum contributions
+#[serde_with::serde_as]
+#[derive(Clone, Serialize, Deserialize, udigest::Digestable)]
+#[serde(bound = "")]
+#[udigest(bound = "")]
+#[udigest(tag = prefixed!("round2_broad"))]
+pub struct MsgRound2Broad<E: Curve, L: SecurityLevel> {
+    /// Random identifier contribution $rid_i$
+    #[serde_as(as = "utils::HexOrBin")]
+    #[udigest(as_bytes)]
+    pub rid: L::KappaBytes,
+    /// Public commitments $X_i^{(j)} = x_i^{(j)} \cdot G$ for all $j$
+    pub X_contributions: Vec<Point<E>>,
+    /// Schnorr commitment $A_i$
+    pub sch_commit: schnorr_pok::Commit<E>,
+    /// Decommitment nonce $u_i$
+    #[serde(with = "hex::serde")]
+    #[udigest(as_bytes)]
+    pub decommit: L::KappaBytes,
+}
+
+/// Round 2 unicast: secret share contribution
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgRound2Uni<E: Curve> {
+    /// $x_i^{(j)}$ — party $i$'s contribution to party $j$'s new share
+    pub contribution: Scalar<E>,
+}
+
+/// Round 3: Schnorr proof of knowledge of new share
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgRound3<E: Curve> {
+    /// Schnorr proof $\psi_i$
+    pub sch_proof: schnorr_pok::Proof<E>,
+}
+
+/// Reliability check echo message
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgReliabilityCheck<D: Digest>(pub digest::Output<D>);
+
+mod unambiguous {
+    use crate::{ExecutionId, SecurityLevel};
+    use generic_ec::{Curve, NonZero, Point};
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("hash_commitment"))]
+    #[udigest(bound = "")]
+    pub struct HashCom<'a, E: Curve, L: SecurityLevel> {
+        pub sid: ExecutionId<'a>,
+        pub party_index: u16,
+        pub decommitment: &'a super::MsgRound2Broad<E, L>,
+    }
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("schnorr_pok"))]
+    #[udigest(bound = "")]
+    pub struct SchnorrPok<'a, E: Curve> {
+        pub sid: ExecutionId<'a>,
+        pub prover: u16,
+        #[udigest(as_bytes)]
+        pub rid: &'a [u8],
+        pub y: NonZero<Point<E>>,
+        pub h: Point<E>,
+    }
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("echo_round"))]
+    #[udigest(bound = "")]
+    pub struct Echo<'a, D: digest::Digest> {
+        pub sid: ExecutionId<'a>,
+        pub commitment: &'a super::MsgRound1<D>,
+    }
+}
+
+/// Runs the non-threshold key refresh protocol following CGGMP24 Figure 7.
+///
+/// Takes an existing n-of-n key share and produces a new share with the
+/// same public key but a different secret share value.
+///
+/// # Panics (debug)
+/// Panics if `old_key_share` has `vss_setup` set (i.e., is a threshold share).
+pub async fn run_key_refresh<E, R, M, L, D>(
+    mut tracer: Option<&mut dyn Tracer>,
+    old_key_share: &CoreKeyShare<E>,
+    reliable_broadcast_enforced: bool,
+    sid: ExecutionId<'_>,
+    rng: &mut R,
+    party: M,
+) -> Result<CoreKeyShare<E>, KeyRefreshError>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+    R: RngCore + CryptoRng,
+    M: Mpc<ProtocolMessage = Msg<E, L, D>>,
+{
+    let i = old_key_share.i;
+    let n = old_key_share.key_info.public_shares.len() as u16;
+
+    debug_assert!(
+        old_key_share.vss_setup.is_none(),
+        "non-threshold refresh called on threshold key share"
+    );
+
+    tracer.protocol_begins();
+
+    // ===== Setup =====
+    tracer.stage("Setup networking");
+    let MpcParty { delivery, .. } = party.into_party();
+    let (incomings, mut outgoings) = delivery.split();
+
+    let mut rounds = RoundsRouter::<Msg<E, L, D>>::builder();
+    let round1 = rounds.add_round(RoundInput::<MsgRound1<D>>::broadcast(i, n));
+    let round1_sync = rounds.add_round(RoundInput::<MsgReliabilityCheck<D>>::broadcast(i, n));
+    let round2_broad = rounds.add_round(RoundInput::<MsgRound2Broad<E, L>>::broadcast(i, n));
+    let round2_uni = rounds.add_round(RoundInput::<MsgRound2Uni<E>>::p2p(i, n));
+    let round3 = rounds.add_round(RoundInput::<MsgRound3<E>>::broadcast(i, n));
+    let mut rounds = rounds.listen(incomings);
+
+    // ===== Round 1: Sample zero-sum contributions and commit =====
+    tracer.round_begins();
+
+    tracer.stage("Sample rid, Schnorr commitment, zero-sum contributions");
+    let mut rid = L::KappaBytes::default();
+    rng.fill_bytes(rid.as_mut());
+
+    let (sch_r, sch_h) = schnorr_pok::prover_commits_ephemeral_secret::<E, _>(rng);
+
+    // Sample n-1 random scalars, then set the n-th so the total sums to zero.
+    // x_contributions[j] is party i's contribution to party j's refresh delta.
+    let mut x_contributions: Vec<Scalar<E>> = (0..n - 1)
+        .map(|_| *SecretScalar::<E>::random(rng).as_ref())
+        .collect();
+    let partial_sum: Scalar<E> = x_contributions.iter().copied().sum();
+    x_contributions.push(-partial_sum);
+    debug_assert_eq!(x_contributions.len(), usize::from(n));
+
+    // Public commitments X_i^(j) = x_i^(j) * G
+    let X_contributions: Vec<Point<E>> = x_contributions
+        .iter()
+        .map(|s| Point::generator() * s)
+        .collect();
+
+    tracer.stage("Compute hash commitment");
+    let my_decommitment = MsgRound2Broad {
+        rid,
+        X_contributions: X_contributions.clone(),
+        sch_commit: sch_h,
+        decommit: {
+            let mut nonce = L::KappaBytes::default();
+            rng.fill_bytes(nonce.as_mut());
+            nonce
+        },
+    };
+    let hash_commit = udigest::hash::<D>(&unambiguous::HashCom {
+        sid,
+        party_index: i,
+        decommitment: &my_decommitment,
+    });
+
+    tracer.send_msg();
+    let my_commitment = MsgRound1 {
+        commitment: hash_commit,
+    };
+    outgoings
+        .send(Outgoing::broadcast(Msg::Round1(my_commitment.clone())))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Round 2: Decommit + P2P =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let commitments = rounds
+        .complete(round1)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    if reliable_broadcast_enforced {
+        tracer.stage("Reliability check: hash round-1 messages");
+        let h_i = udigest::hash_iter::<D>(
+            commitments
+                .iter_including_me(&my_commitment)
+                .map(|commitment| unambiguous::Echo { sid, commitment }),
+        );
+
+        tracer.send_msg();
+        outgoings
+            .send(Outgoing::broadcast(Msg::ReliabilityCheck(
+                MsgReliabilityCheck(h_i.clone()),
+            )))
+            .await
+            .map_err(IoError::send_message)?;
+        tracer.msg_sent();
+
+        tracer.round_begins();
+
+        tracer.receive_msgs();
+        let hashes = rounds
+            .complete(round1_sync)
+            .await
+            .map_err(IoError::receive_message)?;
+        tracer.msgs_received();
+
+        tracer.stage("Reliability check: verify echo hashes");
+        let mismatched = hashes
+            .into_iter_indexed()
+            .filter(|(_j, _msg_id, h_j)| h_i != h_j.0)
+            .map(|(j, msg_id, _)| (j, msg_id))
+            .collect::<Vec<_>>();
+        if !mismatched.is_empty() {
+            return Err(RefreshAborted::Round1NotReliable(mismatched).into());
+        }
+    }
+
+    tracer.send_msg();
+    outgoings
+        .feed(Outgoing::broadcast(Msg::Round2Broad(
+            my_decommitment.clone(),
+        )))
+        .await
+        .map_err(IoError::send_message)?;
+
+    // Unicast x_i^(j) to each peer j
+    let p2p_messages = utils::iter_peers(i, n).map(|j| {
+        Outgoing::p2p(
+            j,
+            Msg::Round2Uni(MsgRound2Uni {
+                contribution: x_contributions[usize::from(j)],
+            }),
+        )
+    });
+    outgoings
+        .send_all(&mut futures_util::stream::iter(p2p_messages.map(Ok)))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Round 3: Verify and Prove =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let decommitments = rounds
+        .complete(round2_broad)
+        .await
+        .map_err(IoError::receive_message)?;
+    let contributions_msg = rounds
+        .complete(round2_uni)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    tracer.stage("Validate decommitments");
+    let blame = utils::collect_blame(&commitments, &decommitments, |j, com, decom| {
+        let expected = udigest::hash::<D>(&unambiguous::HashCom {
+            sid,
+            party_index: j,
+            decommitment: decom,
+        });
+        com.commitment != expected
+    });
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidDecommitment(blame).into());
+    }
+
+    tracer.stage("Validate contribution vector lengths");
+    let blame = decommitments
+        .iter_indexed()
+        .filter(|(_, _, d)| d.X_contributions.len() != usize::from(n))
+        .map(|(j, _, _)| j)
+        .collect::<Vec<_>>();
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidDataSize { parties: blame }.into());
+    }
+
+    tracer.stage("Validate zero-sum property of public contributions");
+    let blame = decommitments
+        .iter_indexed()
+        .filter(|(_, _, d)| {
+            let sum: Point<E> = d.X_contributions.iter().copied().sum();
+            sum != Point::zero()
+        })
+        .map(|(j, _, _)| j)
+        .collect::<Vec<_>>();
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidDataSize { parties: blame }.into());
+    }
+
+    tracer.stage("Validate Feldman (unicast matches public commitment)");
+    // For each peer j: verify x_j^(i) * G == X_j^(i)
+    let blame = decommitments
+        .iter_indexed()
+        .zip(contributions_msg.iter())
+        .filter(|((_, _, d), c)| {
+            d.X_contributions[usize::from(i)] != Point::generator() * c.contribution
+        })
+        .map(|((j, _, _), _)| j)
+        .collect::<Vec<_>>();
+    if !blame.is_empty() {
+        return Err(RefreshAborted::FeldmanVerificationFailed { parties: blame }.into());
+    }
+
+    tracer.stage("Compute joint rid");
+    let rid = decommitments
+        .iter_including_me(&my_decommitment)
+        .map(|d| &d.rid)
+        .fold(L::KappaBytes::default(), utils::xor_array);
+
+    tracer.stage("Compute refreshed secret share");
+    // x_i' = x_i + sum_j x_j^(i)  (including own contribution)
+    let contrib_from_others: Scalar<E> = contributions_msg.iter().map(|m| m.contribution).sum();
+    let contrib_from_self = x_contributions[usize::from(i)];
+    let mut new_x_scalar: Scalar<E> = contrib_from_others + contrib_from_self + &old_key_share.x;
+    let new_x = SecretScalar::new(&mut new_x_scalar);
+    let new_x = NonZero::from_secret_scalar(new_x).ok_or(RefreshBug::ZeroShare)?;
+
+    tracer.stage("Compute new public shares");
+    // For each party l: X_l' = X_l + sum_j X_j^(l)
+    let new_public_shares: Vec<NonZero<Point<E>>> = (0..n)
+        .map(|l| {
+            let refresh_sum: Point<E> = decommitments
+                .iter_including_me(&my_decommitment)
+                .map(|d| d.X_contributions[usize::from(l)])
+                .sum();
+            let new_pub = old_key_share.key_info.public_shares[usize::from(l)] + refresh_sum;
+            NonZero::from_point(new_pub).ok_or(RefreshBug::ZeroShare)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    tracer.stage("Prove knowledge of new share");
+    let challenge = Scalar::from_hash::<D>(&unambiguous::SchnorrPok {
+        sid,
+        prover: i,
+        rid: rid.as_ref(),
+        y: new_public_shares[usize::from(i)],
+        h: my_decommitment.sch_commit.0,
+    });
+    let challenge = schnorr_pok::Challenge { nonce: challenge };
+    let sch_proof = schnorr_pok::prove(&sch_r, &challenge, &new_x);
+
+    tracer.send_msg();
+    outgoings
+        .send(Outgoing::broadcast(Msg::Round3(MsgRound3 {
+            sch_proof: sch_proof.clone(),
+        })))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Output: Verify Schnorr proofs =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let sch_proofs = rounds
+        .complete(round3)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    tracer.stage("Validate Schnorr proofs");
+    let blame = utils::collect_blame(&decommitments, &sch_proofs, |j, decom, proof| {
+        let ch = Scalar::from_hash::<D>(&unambiguous::SchnorrPok {
+            sid,
+            prover: j,
+            rid: rid.as_ref(),
+            y: new_public_shares[usize::from(j)],
+            h: decom.sch_commit.0,
+        });
+        let ch = schnorr_pok::Challenge { nonce: ch };
+        proof
+            .sch_proof
+            .verify(&decom.sch_commit, &ch, &new_public_shares[usize::from(j)])
+            .is_err()
+    });
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidSchnorrProof(blame).into());
+    }
+
+    // Sanity: public key must be preserved.
+    // sum(new_public_shares) should equal old public key because
+    // each party's contributions sum to zero.
+    tracer.stage("Verify public key invariant");
+    let pk_sum: Point<E> = new_public_shares.iter().copied().sum();
+    if NonZero::from_point(pk_sum).ok_or(RefreshBug::ZeroPk)? != old_key_share.shared_public_key {
+        return Err(RefreshBug::PublicKeyMismatch.into());
+    }
+
+    tracer.protocol_ends();
+
+    Ok(DirtyCoreKeyShare {
+        i,
+        key_info: DirtyKeyInfo {
+            curve: Default::default(),
+            shared_public_key: old_key_share.shared_public_key,
+            public_shares: new_public_shares,
+            vss_setup: None,
+            #[cfg(feature = "hd-wallet")]
+            chain_code: old_key_share.key_info.chain_code,
+        },
+        x: new_x,
+    }
+    .validate()
+    .map_err(|e| RefreshBug::InvalidKeyShare(e.into_error()))?)
+}

--- a/cggmp24-keygen/src/key_refresh_threshold.rs
+++ b/cggmp24-keygen/src/key_refresh_threshold.rs
@@ -1,0 +1,500 @@
+//! Threshold (t-of-n) key share refresh protocol
+//!
+//! Implements the share-refresh portion of CGGMP24 Appendix F.1.1, omitting
+//! auxiliary data generation per [issue #162](https://github.com/LFDT-Lockness/cggmp21/issues/162).
+//!
+//! # Protocol
+//!
+//! All $n$ parties hold polynomial shares $x_i = F(I_i)$ where $F(0) = x$.
+//! Each party $i$ samples a random degree-$(t-1)$ polynomial $g^{(i)}(X)$ and
+//! defines the zero-sharing polynomial $f^{(i)}(X) = g^{(i)}(X) - g^{(i)}(0)$.
+//! This guarantees $f^{(i)}(0) = 0$.
+//!
+//! After Feldman VSS verification and Schnorr proofs, each party computes:
+//! $$x_i' = x_i + \sum_j f^{(j)}(I_i)$$
+//!
+//! The secret is preserved: $F'(0) = F(0) + \sum_j f^{(j)}(0) = x + 0 = x$.
+//!
+//! # Rounds
+//!
+//! 1. **Commit**: hash commitment to public polynomial and Schnorr commit
+//! 2. **(Optional) Reliability check**: echo-broadcast
+//! 3. **Decommit + P2P shares**: broadcast public polynomial, unicast evaluations
+//! 4. **Prove**: Schnorr proof of knowledge of new secret share
+
+use alloc::vec::Vec;
+
+use digest::Digest;
+use generic_ec::{Curve, NonZero, Point, Scalar, SecretScalar};
+use generic_ec_zkp::{polynomial::Polynomial, schnorr_pok};
+use rand_core::{CryptoRng, RngCore};
+use round_based::{
+    rounds_router::simple_store::RoundInput, rounds_router::RoundsRouter, Delivery, Mpc, MpcParty,
+    Outgoing, ProtocolMessage, SinkExt,
+};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::progress::Tracer;
+use crate::{
+    errors::IoError,
+    key_share::{CoreKeyShare, DirtyCoreKeyShare, DirtyKeyInfo, Validate, VssSetup},
+    security_level::SecurityLevel,
+    utils, ExecutionId,
+};
+
+use super::{KeyRefreshError, RefreshAborted, RefreshBug};
+
+macro_rules! prefixed {
+    ($name:tt) => {
+        concat!("dfns.cggmp24.key_refresh.threshold.", $name)
+    };
+}
+
+/// Message of threshold key refresh protocol
+#[derive(ProtocolMessage, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub enum Msg<E: Curve, L: SecurityLevel, D: Digest> {
+    /// Round 1: hash commitment
+    Round1(MsgRound1<D>),
+    /// Round 2a: decommitment (broadcast)
+    Round2Broad(MsgRound2Broad<E, L>),
+    /// Round 2b: secret share evaluation (P2P)
+    Round2Uni(MsgRound2Uni<E>),
+    /// Round 3: Schnorr proof
+    Round3(MsgRound3<E>),
+    /// Reliability check message (optional)
+    ReliabilityCheck(MsgReliabilityCheck<D>),
+}
+
+/// Round 1 commitment
+#[derive(Clone, Serialize, Deserialize, udigest::Digestable)]
+#[serde(bound = "")]
+#[udigest(bound = "")]
+#[udigest(tag = prefixed!("round1"))]
+pub struct MsgRound1<D: Digest> {
+    /// Hash commitment $V_i$
+    #[udigest(as_bytes)]
+    pub commitment: digest::Output<D>,
+}
+
+/// Round 2 broadcast: public polynomial + Schnorr commit
+///
+/// Contains $G^{(i)}$, the public polynomial of the raw random polynomial
+/// $g^{(i)}$. The verifier derives the zero-sharing public polynomial as
+/// $F^{(i)}(X) = G^{(i)}(X) - G^{(i)}(0)$.
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize, udigest::Digestable)]
+#[serde(bound = "")]
+#[udigest(bound = "")]
+#[udigest(tag = prefixed!("round2_broad"))]
+pub struct MsgRound2Broad<E: Curve, L: SecurityLevel> {
+    /// Random identifier contribution $rid_i$
+    #[serde_as(as = "utils::HexOrBin")]
+    #[udigest(as_bytes)]
+    pub rid: L::KappaBytes,
+    /// Public polynomial $G^{(i)} = g^{(i)} \cdot G$
+    ///
+    /// Degree $t-1$. The zero-sharing public polynomial is
+    /// $F^{(i)}(X) = G^{(i)}(X) - G^{(i)}.coefs\[0\]$.
+    pub G_poly: Polynomial<Point<E>>,
+    /// Schnorr commitment $A_i$
+    pub sch_commit: schnorr_pok::Commit<E>,
+    /// Decommitment nonce $u_i$
+    #[serde(with = "hex::serde")]
+    #[udigest(as_bytes)]
+    pub decommit: L::KappaBytes,
+}
+
+/// Round 2 unicast: secret share evaluation
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgRound2Uni<E: Curve> {
+    /// $\sigma_{i,j} = f^{(i)}(I_j) = g^{(i)}(I_j) - g^{(i)}(0)$
+    pub sigma: Scalar<E>,
+}
+
+/// Round 3: Schnorr proof of knowledge of new share
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgRound3<E: Curve> {
+    /// Schnorr proof $\psi_i$
+    pub sch_proof: schnorr_pok::Proof<E>,
+}
+
+/// Reliability check echo
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct MsgReliabilityCheck<D: Digest>(pub digest::Output<D>);
+
+mod unambiguous {
+    use generic_ec::{Curve, NonZero, Point};
+
+    use crate::{ExecutionId, SecurityLevel};
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("hash_commitment"))]
+    #[udigest(bound = "")]
+    pub struct HashCom<'a, E: Curve, L: SecurityLevel> {
+        pub sid: ExecutionId<'a>,
+        pub party_index: u16,
+        pub decommitment: &'a super::MsgRound2Broad<E, L>,
+    }
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("schnorr_pok"))]
+    #[udigest(bound = "")]
+    pub struct SchnorrPok<'a, E: Curve> {
+        pub sid: ExecutionId<'a>,
+        pub prover: u16,
+        #[udigest(as_bytes)]
+        pub rid: &'a [u8],
+        pub y: NonZero<Point<E>>,
+        pub h: Point<E>,
+    }
+
+    #[derive(udigest::Digestable)]
+    #[udigest(tag = prefixed!("echo_round"))]
+    #[udigest(bound = "")]
+    pub struct Echo<'a, D: digest::Digest> {
+        pub sid: ExecutionId<'a>,
+        pub commitment: &'a super::MsgRound1<D>,
+    }
+}
+
+/// Runs the threshold key refresh protocol.
+///
+/// Takes an existing t-of-n key share and produces a new share with the
+/// same public key, threshold, and VSS setup but different secret share value.
+///
+/// # Errors
+/// Returns `KeyRefreshError` if the old share has no VSS setup or if any
+/// party misbehaves (invalid commitments, proofs, or Feldman checks).
+pub async fn run_threshold_key_refresh<E, R, M, L, D>(
+    mut tracer: Option<&mut dyn Tracer>,
+    old_key_share: &CoreKeyShare<E>,
+    reliable_broadcast_enforced: bool,
+    sid: ExecutionId<'_>,
+    rng: &mut R,
+    party: M,
+) -> Result<CoreKeyShare<E>, KeyRefreshError>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+    R: RngCore + CryptoRng,
+    M: Mpc<ProtocolMessage = Msg<E, L, D>>,
+{
+    let i = old_key_share.i;
+    let n = old_key_share.key_info.public_shares.len() as u16;
+
+    let vss = old_key_share
+        .vss_setup
+        .as_ref()
+        .ok_or(RefreshBug::MissingVssSetup)?;
+    let t = vss.min_signers;
+
+    tracer.protocol_begins();
+
+    // ===== Setup =====
+    tracer.stage("Setup networking");
+    let MpcParty { delivery, .. } = party.into_party();
+    let (incomings, mut outgoings) = delivery.split();
+
+    let mut rounds = RoundsRouter::<Msg<E, L, D>>::builder();
+    let round1 = rounds.add_round(RoundInput::<MsgRound1<D>>::broadcast(i, n));
+    let round1_sync = rounds.add_round(RoundInput::<MsgReliabilityCheck<D>>::broadcast(i, n));
+    let round2_broad = rounds.add_round(RoundInput::<MsgRound2Broad<E, L>>::broadcast(i, n));
+    let round2_uni = rounds.add_round(RoundInput::<MsgRound2Uni<E>>::p2p(i, n));
+    let round3 = rounds.add_round(RoundInput::<MsgRound3<E>>::broadcast(i, n));
+    let mut rounds = rounds.listen(incomings);
+
+    // ===== Round 1: Sample random polynomial and commit =====
+    tracer.round_begins();
+
+    tracer.stage("Sample rid, Schnorr commitment, random polynomial");
+    let mut rid = L::KappaBytes::default();
+    rng.fill_bytes(rid.as_mut());
+
+    let (sch_r, sch_h) = schnorr_pok::prover_commits_ephemeral_secret::<E, _>(rng);
+
+    // Sample random polynomial g(X) of degree t-1.
+    // The zero-sharing polynomial is f(X) = g(X) - g(0), so f(0) = 0.
+    let g = Polynomial::<SecretScalar<E>>::sample(rng, usize::from(t) - 1);
+    let g_at_zero: Scalar<E> = g.value(&Scalar::zero());
+    let G_poly = &g * &Point::generator();
+
+    // Compute sigma_{i,j} = f(I_j) = g(I_j) - g(0) for each party j
+    let sigmas: Vec<Scalar<E>> = (0..n)
+        .map(|j| {
+            let I_j = &vss.I[usize::from(j)];
+            let g_at_I_j: Scalar<E> = g.value(I_j);
+            g_at_I_j - g_at_zero
+        })
+        .collect();
+
+    tracer.stage("Compute hash commitment");
+    let my_decommitment = MsgRound2Broad {
+        rid,
+        G_poly: G_poly.clone(),
+        sch_commit: sch_h,
+        decommit: {
+            let mut nonce = L::KappaBytes::default();
+            rng.fill_bytes(nonce.as_mut());
+            nonce
+        },
+    };
+    let hash_commit = udigest::hash::<D>(&unambiguous::HashCom {
+        sid,
+        party_index: i,
+        decommitment: &my_decommitment,
+    });
+
+    tracer.send_msg();
+    let my_commitment = MsgRound1 {
+        commitment: hash_commit,
+    };
+    outgoings
+        .send(Outgoing::broadcast(Msg::Round1(my_commitment.clone())))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Round 2: Decommit + P2P =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let commitments = rounds
+        .complete(round1)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    if reliable_broadcast_enforced {
+        tracer.stage("Reliability check: hash round-1 messages");
+        let h_i = udigest::hash_iter::<D>(
+            commitments
+                .iter_including_me(&my_commitment)
+                .map(|commitment| unambiguous::Echo { sid, commitment }),
+        );
+
+        tracer.send_msg();
+        outgoings
+            .send(Outgoing::broadcast(Msg::ReliabilityCheck(
+                MsgReliabilityCheck(h_i.clone()),
+            )))
+            .await
+            .map_err(IoError::send_message)?;
+        tracer.msg_sent();
+
+        tracer.round_begins();
+
+        tracer.receive_msgs();
+        let hashes = rounds
+            .complete(round1_sync)
+            .await
+            .map_err(IoError::receive_message)?;
+        tracer.msgs_received();
+
+        tracer.stage("Reliability check: verify echo hashes");
+        let mismatched = hashes
+            .into_iter_indexed()
+            .filter(|(_j, _msg_id, h_j)| h_i != h_j.0)
+            .map(|(j, msg_id, _)| (j, msg_id))
+            .collect::<Vec<_>>();
+        if !mismatched.is_empty() {
+            return Err(RefreshAborted::Round1NotReliable(mismatched).into());
+        }
+    }
+
+    tracer.send_msg();
+    outgoings
+        .feed(Outgoing::broadcast(Msg::Round2Broad(
+            my_decommitment.clone(),
+        )))
+        .await
+        .map_err(IoError::send_message)?;
+
+    // Send sigma_{i,j} to each peer j
+    let p2p_messages = utils::iter_peers(i, n).map(|j| {
+        Outgoing::p2p(
+            j,
+            Msg::Round2Uni(MsgRound2Uni {
+                sigma: sigmas[usize::from(j)],
+            }),
+        )
+    });
+    outgoings
+        .send_all(&mut futures_util::stream::iter(p2p_messages.map(Ok)))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Round 3: Verify and Prove =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let decommitments = rounds
+        .complete(round2_broad)
+        .await
+        .map_err(IoError::receive_message)?;
+    let sigmas_msg = rounds
+        .complete(round2_uni)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    tracer.stage("Validate decommitments");
+    let blame = utils::collect_blame(&commitments, &decommitments, |j, com, decom| {
+        let expected = udigest::hash::<D>(&unambiguous::HashCom {
+            sid,
+            party_index: j,
+            decommitment: decom,
+        });
+        com.commitment != expected
+    });
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidDecommitment(blame).into());
+    }
+
+    tracer.stage("Validate polynomial degree");
+    let blame = decommitments
+        .iter_indexed()
+        .filter(|(_, _, d)| d.G_poly.degree() + 1 != usize::from(t))
+        .map(|(j, _, _)| j)
+        .collect::<Vec<_>>();
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidDataSize { parties: blame }.into());
+    }
+
+    tracer.stage("Validate Feldman VSS (zero-sharing)");
+    // For party j's polynomial: f^(j)(I_i) = g^(j)(I_i) - g^(j)(0)
+    // On the curve: G_poly_j(I_i) - G_poly_j.coefs()[0] should equal sigma_{j,i} * G
+    let I_i = &vss.I[usize::from(i)];
+    let blame = decommitments
+        .iter_indexed()
+        .zip(sigmas_msg.iter())
+        .filter(|((_, _, d), s)| {
+            let G_eval_at_I_i: Point<E> = d.G_poly.value(I_i);
+            let G_const: Point<E> = d.G_poly.coefs()[0];
+            // F^(j)(I_i) = G_poly_j(I_i) - G_poly_j(0)
+            let F_eval = G_eval_at_I_i - G_const;
+            F_eval != Point::generator() * s.sigma
+        })
+        .map(|((j, _, _), _)| j)
+        .collect::<Vec<_>>();
+    if !blame.is_empty() {
+        return Err(RefreshAborted::FeldmanVerificationFailed { parties: blame }.into());
+    }
+
+    tracer.stage("Compute joint rid");
+    let rid = decommitments
+        .iter_including_me(&my_decommitment)
+        .map(|d| &d.rid)
+        .fold(L::KappaBytes::default(), utils::xor_array);
+
+    tracer.stage("Compute refreshed secret share");
+    // x_i' = x_i + sum_j sigma_{j,i}   (including own contribution)
+    let sigma_from_others: Scalar<E> = sigmas_msg.iter().map(|msg| msg.sigma).sum();
+    let sigma_from_self = sigmas[usize::from(i)];
+    let mut new_x_scalar: Scalar<E> = sigma_from_others + sigma_from_self + &old_key_share.x;
+    let new_x = SecretScalar::new(&mut new_x_scalar);
+    let new_x = NonZero::from_secret_scalar(new_x).ok_or(RefreshBug::ZeroShare)?;
+
+    tracer.stage("Compute new public shares");
+    // For each party l: X_l' = X_l + sum_j F^(j)(I_l)
+    // where F^(j)(I_l) = G_poly_j(I_l) - G_poly_j.coefs()[0]
+    let new_public_shares: Vec<NonZero<Point<E>>> = (0..n)
+        .map(|l| {
+            let I_l = &vss.I[usize::from(l)];
+            let refresh_sum: Point<E> = decommitments
+                .iter_including_me(&my_decommitment)
+                .map(|d| {
+                    let eval: Point<E> = d.G_poly.value(I_l);
+                    let constant: Point<E> = d.G_poly.coefs()[0];
+                    eval - constant
+                })
+                .sum();
+            let new_pub = old_key_share.key_info.public_shares[usize::from(l)] + refresh_sum;
+            NonZero::from_point(new_pub).ok_or(RefreshBug::ZeroShare)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    tracer.stage("Prove knowledge of new share");
+    let challenge = Scalar::from_hash::<D>(&unambiguous::SchnorrPok {
+        sid,
+        prover: i,
+        rid: rid.as_ref(),
+        y: new_public_shares[usize::from(i)],
+        h: my_decommitment.sch_commit.0,
+    });
+    let challenge = schnorr_pok::Challenge { nonce: challenge };
+    let sch_proof = schnorr_pok::prove(&sch_r, &challenge, &new_x);
+
+    tracer.send_msg();
+    outgoings
+        .send(Outgoing::broadcast(Msg::Round3(MsgRound3 {
+            sch_proof: sch_proof.clone(),
+        })))
+        .await
+        .map_err(IoError::send_message)?;
+    tracer.msg_sent();
+
+    // ===== Output: Verify Schnorr proofs =====
+    tracer.round_begins();
+
+    tracer.receive_msgs();
+    let sch_proofs = rounds
+        .complete(round3)
+        .await
+        .map_err(IoError::receive_message)?;
+    tracer.msgs_received();
+
+    tracer.stage("Validate Schnorr proofs");
+    let blame = utils::collect_blame(&decommitments, &sch_proofs, |j, decom, proof| {
+        let ch = Scalar::from_hash::<D>(&unambiguous::SchnorrPok {
+            sid,
+            prover: j,
+            rid: rid.as_ref(),
+            y: new_public_shares[usize::from(j)],
+            h: decom.sch_commit.0,
+        });
+        let ch = schnorr_pok::Challenge { nonce: ch };
+        proof
+            .sch_proof
+            .verify(&decom.sch_commit, &ch, &new_public_shares[usize::from(j)])
+            .is_err()
+    });
+    if !blame.is_empty() {
+        return Err(RefreshAborted::InvalidSchnorrProof(blame).into());
+    }
+
+    // Sanity: the shared public key must not have changed.
+    // Since each f^(j)(0) = 0, the sum of refresh polynomials at 0 is the zero point.
+    tracer.stage("Verify public key invariant");
+    let refresh_at_zero: Point<E> = decommitments
+        .iter_including_me(&my_decommitment)
+        .map(|_d| Point::zero())
+        .sum();
+    debug_assert_eq!(refresh_at_zero, Point::zero());
+
+    tracer.protocol_ends();
+
+    Ok(DirtyCoreKeyShare {
+        i,
+        key_info: DirtyKeyInfo {
+            curve: Default::default(),
+            shared_public_key: old_key_share.shared_public_key,
+            public_shares: new_public_shares,
+            vss_setup: Some(VssSetup {
+                min_signers: t,
+                I: vss.I.clone(),
+            }),
+            #[cfg(feature = "hd-wallet")]
+            chain_code: old_key_share.key_info.chain_code,
+        },
+        x: new_x,
+    }
+    .validate()
+    .map_err(|err| RefreshBug::InvalidKeyShare(err.into_error()))?)
+}

--- a/cggmp24-keygen/src/lib.rs
+++ b/cggmp24-keygen/src/lib.rs
@@ -21,6 +21,11 @@ mod non_threshold;
 /// Threshold DKG specific types
 mod threshold;
 
+/// Non-threshold key refresh specific types
+mod key_refresh_non_threshold;
+/// Threshold key refresh specific types
+mod key_refresh_threshold;
+
 mod errors;
 mod execution_id;
 mod utils;
@@ -61,6 +66,18 @@ pub mod msg {
     /// Messages types related to threshold DKG protocol
     pub mod threshold {
         pub use crate::threshold::{
+            Msg, MsgReliabilityCheck, MsgRound1, MsgRound2Broad, MsgRound2Uni, MsgRound3,
+        };
+    }
+    /// Messages types related to non-threshold key refresh protocol
+    pub mod key_refresh_non_threshold {
+        pub use crate::key_refresh_non_threshold::{
+            Msg, MsgReliabilityCheck, MsgRound1, MsgRound2Broad, MsgRound2Uni, MsgRound3,
+        };
+    }
+    /// Messages types related to threshold key refresh protocol
+    pub mod key_refresh_threshold {
+        pub use crate::key_refresh_threshold::{
             Msg, MsgReliabilityCheck, MsgRound1, MsgRound2Broad, MsgRound2Uni, MsgRound3,
         };
     }
@@ -349,6 +366,7 @@ enum KeygenAborted {
     MissingChainCode(Vec<utils::AbortBlame>),
 }
 
+/// Internal bugs for keygen (not caused by malicious parties)
 #[derive(Debug, displaydoc::Display)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 enum Bug {
@@ -371,4 +389,274 @@ enum Bug {
 /// (where $n$ is amount of parties in the protocol).
 pub fn keygen<E: Curve>(eid: ExecutionId, i: u16, n: u16) -> KeygenBuilder<E> {
     KeygenBuilder::new(eid, i, n)
+}
+
+// ========== Key Refresh Protocol ==========
+
+/// Key refresh protocol error
+#[derive(Debug, displaydoc::Display)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[displaydoc("key refresh protocol failed to complete")]
+pub struct KeyRefreshError(#[cfg_attr(feature = "std", source)] RefreshReason);
+
+crate::errors::impl_from! {
+    impl From for KeyRefreshError {
+        err: RefreshAborted => KeyRefreshError(RefreshReason::Aborted(err)),
+        err: IoError => KeyRefreshError(RefreshReason::IoError(err)),
+        err: RefreshBug => KeyRefreshError(RefreshReason::Bug(err)),
+    }
+}
+
+#[derive(Debug, displaydoc::Display)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+enum RefreshReason {
+    /// Protocol was maliciously aborted by another party
+    #[displaydoc("protocol was aborted by malicious party")]
+    Aborted(#[cfg_attr(feature = "std", source)] RefreshAborted),
+    #[displaydoc("i/o error")]
+    IoError(#[cfg_attr(feature = "std", source)] IoError),
+    /// Bug occurred
+    #[displaydoc("bug occurred")]
+    Bug(RefreshBug),
+}
+
+/// Error indicating that key refresh was aborted by malicious party
+#[derive(Debug, displaydoc::Display)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+enum RefreshAborted {
+    #[displaydoc("party decommitment doesn't match commitment: {0:?}")]
+    InvalidDecommitment(Vec<utils::AbortBlame>),
+    #[displaydoc("party provided invalid schnorr proof: {0:?}")]
+    InvalidSchnorrProof(Vec<utils::AbortBlame>),
+    #[displaydoc("party secret share is not consistent: {parties:?}")]
+    FeldmanVerificationFailed { parties: Vec<u16> },
+    #[displaydoc("party data size is not suitable for parameters: {parties:?}")]
+    InvalidDataSize { parties: Vec<u16> },
+    #[displaydoc("round1 wasn't reliable")]
+    Round1NotReliable(Vec<(PartyIndex, MsgId)>),
+}
+
+/// Internal bugs specific to key refresh (not caused by malicious parties)
+#[derive(Debug, displaydoc::Display)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+enum RefreshBug {
+    #[displaydoc("resulting key share is not valid")]
+    InvalidKeyShare(#[cfg_attr(feature = "std", source)] InvalidCoreShare),
+    #[displaydoc("refreshed share is zero - probability of that is negligible")]
+    ZeroShare,
+    #[displaydoc("shared public key is zero - probability of that is negligible")]
+    ZeroPk,
+    #[displaydoc("public key changed after refresh - this is a bug")]
+    PublicKeyMismatch,
+    #[displaydoc("threshold refresh called on non-threshold key share (missing vss_setup)")]
+    MissingVssSetup,
+}
+
+/// Key refresh entry point for non-threshold (n-of-n) key shares
+///
+/// Refreshes secret shares without changing the public key or threshold.
+/// Uses the same execution model as DKG: provide an execution ID, key share,
+/// and MPC party, and receive the refreshed key share.
+///
+/// # Example
+/// ```ignore
+/// let eid = ExecutionId::new(b"unique refresh session id");
+/// let new_share = key_refresh(eid, &old_share)
+///     .start(&mut rng, party)
+///     .await?;
+/// ```
+pub fn key_refresh<'a, E: Curve>(
+    eid: ExecutionId<'a>,
+    old_key_share: &'a CoreKeyShare<E>,
+) -> KeyRefreshBuilder<'a, E> {
+    KeyRefreshBuilder::new(eid, old_key_share)
+}
+
+/// Builder for non-threshold key refresh protocol
+pub type KeyRefreshBuilder<
+    'a,
+    E,
+    L = crate::default_choice::SecurityLevel,
+    D = crate::default_choice::Digest,
+> = GenericKeyRefreshBuilder<'a, E, NonThreshold, L, D>;
+
+/// Builder for threshold key refresh protocol
+pub type ThresholdKeyRefreshBuilder<
+    'a,
+    E,
+    L = crate::default_choice::SecurityLevel,
+    D = crate::default_choice::Digest,
+> = GenericKeyRefreshBuilder<'a, E, WithThreshold, L, D>;
+
+/// Key refresh protocol builder
+pub struct GenericKeyRefreshBuilder<'a, E: Curve, M, L: SecurityLevel, D: Digest> {
+    old_key_share: &'a CoreKeyShare<E>,
+    reliable_broadcast_enforced: bool,
+    execution_id: ExecutionId<'a>,
+    tracer: Option<&'a mut dyn Tracer>,
+    _mode: core::marker::PhantomData<(M, L, D)>,
+}
+
+impl<'a, E, L, D> GenericKeyRefreshBuilder<'a, E, NonThreshold, L, D>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+{
+    /// Constructs a non-threshold key refresh builder
+    pub fn new(eid: ExecutionId<'a>, old_key_share: &'a CoreKeyShare<E>) -> Self {
+        Self {
+            old_key_share,
+            reliable_broadcast_enforced: true,
+            execution_id: eid,
+            tracer: None,
+            _mode: core::marker::PhantomData,
+        }
+    }
+
+    /// Switches to threshold key refresh mode
+    pub fn set_threshold(self) -> GenericKeyRefreshBuilder<'a, E, WithThreshold, L, D> {
+        GenericKeyRefreshBuilder {
+            old_key_share: self.old_key_share,
+            reliable_broadcast_enforced: self.reliable_broadcast_enforced,
+            execution_id: self.execution_id,
+            tracer: self.tracer,
+            _mode: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, E, L, D, M> GenericKeyRefreshBuilder<'a, E, M, L, D>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+{
+    /// Specifies another hash function to use
+    pub fn set_digest<D2>(self) -> GenericKeyRefreshBuilder<'a, E, M, L, D2>
+    where
+        D2: Digest + Clone + 'static,
+    {
+        GenericKeyRefreshBuilder {
+            old_key_share: self.old_key_share,
+            reliable_broadcast_enforced: self.reliable_broadcast_enforced,
+            execution_id: self.execution_id,
+            tracer: self.tracer,
+            _mode: core::marker::PhantomData,
+        }
+    }
+
+    /// Specifies [security level](crate::security_level)
+    pub fn set_security_level<L2>(self) -> GenericKeyRefreshBuilder<'a, E, M, L2, D>
+    where
+        L2: SecurityLevel,
+    {
+        GenericKeyRefreshBuilder {
+            old_key_share: self.old_key_share,
+            reliable_broadcast_enforced: self.reliable_broadcast_enforced,
+            execution_id: self.execution_id,
+            tracer: self.tracer,
+            _mode: core::marker::PhantomData,
+        }
+    }
+
+    /// Sets a tracer that tracks progress of protocol execution
+    pub fn set_progress_tracer(mut self, tracer: &'a mut dyn Tracer) -> Self {
+        self.tracer = Some(tracer);
+        self
+    }
+
+    /// Whether to enforce reliable broadcast via echo round
+    pub fn enforce_reliable_broadcast(self, enforce: bool) -> Self {
+        Self {
+            reliable_broadcast_enforced: enforce,
+            ..self
+        }
+    }
+}
+
+impl<'a, E, L, D> GenericKeyRefreshBuilder<'a, E, NonThreshold, L, D>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+{
+    /// Starts the non-threshold key refresh protocol
+    pub async fn start<R, M>(
+        self,
+        rng: &mut R,
+        party: M,
+    ) -> Result<CoreKeyShare<E>, KeyRefreshError>
+    where
+        R: RngCore + CryptoRng,
+        M: Mpc<ProtocolMessage = key_refresh_non_threshold::Msg<E, L, D>>,
+    {
+        key_refresh_non_threshold::run_key_refresh(
+            self.tracer,
+            self.old_key_share,
+            self.reliable_broadcast_enforced,
+            self.execution_id,
+            rng,
+            party,
+        )
+        .await
+    }
+
+    /// Returns a state machine for sync key refresh
+    #[cfg(feature = "state-machine")]
+    pub fn into_state_machine<R>(
+        self,
+        rng: &'a mut R,
+    ) -> impl round_based::state_machine::StateMachine<
+        Output = Result<CoreKeyShare<E>, KeyRefreshError>,
+        Msg = key_refresh_non_threshold::Msg<E, L, D>,
+    > + 'a
+    where
+        R: RngCore + CryptoRng,
+    {
+        round_based::state_machine::wrap_protocol(|party| self.start(rng, party))
+    }
+}
+
+impl<'a, E, L, D> GenericKeyRefreshBuilder<'a, E, WithThreshold, L, D>
+where
+    E: Curve,
+    L: SecurityLevel,
+    D: Digest + Clone + 'static,
+{
+    /// Starts the threshold key refresh protocol
+    pub async fn start<R, M>(
+        self,
+        rng: &mut R,
+        party: M,
+    ) -> Result<CoreKeyShare<E>, KeyRefreshError>
+    where
+        R: RngCore + CryptoRng,
+        M: Mpc<ProtocolMessage = key_refresh_threshold::Msg<E, L, D>>,
+    {
+        key_refresh_threshold::run_threshold_key_refresh(
+            self.tracer,
+            self.old_key_share,
+            self.reliable_broadcast_enforced,
+            self.execution_id,
+            rng,
+            party,
+        )
+        .await
+    }
+
+    /// Returns a state machine for sync threshold key refresh
+    #[cfg(feature = "state-machine")]
+    pub fn into_state_machine<R>(
+        self,
+        rng: &'a mut R,
+    ) -> impl round_based::state_machine::StateMachine<
+        Output = Result<CoreKeyShare<E>, KeyRefreshError>,
+        Msg = key_refresh_threshold::Msg<E, L, D>,
+    > + 'a
+    where
+        R: RngCore + CryptoRng,
+    {
+        round_based::state_machine::wrap_protocol(|party| self.start(rng, party))
+    }
 }

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -371,6 +371,13 @@ pub mod keygen {
         ThresholdKeygenBuilder, WithThreshold,
     };
 
+    // Key share refresh protocol re-exports
+    #[doc(inline)]
+    pub use cggmp24_keygen::{
+        key_refresh, GenericKeyRefreshBuilder, KeyRefreshBuilder, KeyRefreshError,
+        ThresholdKeyRefreshBuilder,
+    };
+
     pub use msg::non_threshold::Msg as NonThresholdMsg;
     pub use msg::threshold::Msg as ThresholdMsg;
 }

--- a/tests/tests/it/key_share_refresh.rs
+++ b/tests/tests/it/key_share_refresh.rs
@@ -1,0 +1,325 @@
+//! Integration tests for key share refresh protocol
+//!
+//! Tests both non-threshold and threshold refresh, verifying:
+//! 1. Secret key is preserved after refresh
+//! 2. Individual shares change
+//! 3. Public key is preserved
+//! 4. Multiple refresh rounds work correctly
+//! 5. Old shares are incompatible with new shares
+
+use generic_ec::{Curve, Point};
+use rand::Rng;
+use rand_dev::DevRng;
+
+use cggmp24::{
+    key_share::reconstruct_secret_key, keygen::key_refresh, ExecutionId, IncompleteKeyShare,
+};
+
+/// Helper: run non-threshold keygen for n parties
+fn run_non_threshold_keygen<E>(rng: &mut DevRng, n: u16) -> Vec<IncompleteKeyShare<E>>
+where
+    E: Curve,
+{
+    let eid: [u8; 32] = rng.gen();
+    let eid = ExecutionId::new(&eid);
+
+    round_based::sim::run(n, |i, party| {
+        let mut party_rng = rng.fork();
+        async move {
+            cggmp24::keygen::<E>(eid, i, n)
+                .enforce_reliable_broadcast(false)
+                .start(&mut party_rng, party)
+                .await
+        }
+    })
+    .unwrap()
+    .expect_ok()
+    .into_vec()
+}
+
+/// Helper: run threshold keygen for t-of-n
+fn run_threshold_keygen<E>(rng: &mut DevRng, t: u16, n: u16) -> Vec<IncompleteKeyShare<E>>
+where
+    E: Curve,
+{
+    let eid: [u8; 32] = rng.gen();
+    let eid = ExecutionId::new(&eid);
+
+    round_based::sim::run(n, |i, party| {
+        let mut party_rng = rng.fork();
+        async move {
+            cggmp24::keygen::<E>(eid, i, n)
+                .set_threshold(t)
+                .enforce_reliable_broadcast(false)
+                .start(&mut party_rng, party)
+                .await
+        }
+    })
+    .unwrap()
+    .expect_ok()
+    .into_vec()
+}
+
+/// Helper: run non-threshold share refresh
+fn run_non_threshold_refresh<E>(
+    rng: &mut DevRng,
+    old_shares: &[IncompleteKeyShare<E>],
+) -> Vec<IncompleteKeyShare<E>>
+where
+    E: Curve,
+{
+    let eid: [u8; 32] = rng.gen();
+    let eid = ExecutionId::new(&eid);
+
+    round_based::sim::run_with_setup(old_shares.iter(), |_i, party, share| {
+        let mut party_rng = rng.fork();
+        async move {
+            key_refresh(eid, share)
+                .enforce_reliable_broadcast(false)
+                .start(&mut party_rng, party)
+                .await
+        }
+    })
+    .unwrap()
+    .expect_ok()
+    .into_vec()
+}
+
+/// Helper: run threshold share refresh
+fn run_threshold_refresh<E>(
+    rng: &mut DevRng,
+    old_shares: &[IncompleteKeyShare<E>],
+) -> Vec<IncompleteKeyShare<E>>
+where
+    E: Curve,
+{
+    let eid: [u8; 32] = rng.gen();
+    let eid = ExecutionId::new(&eid);
+
+    round_based::sim::run_with_setup(old_shares.iter(), |_i, party, share| {
+        let mut party_rng = rng.fork();
+        async move {
+            key_refresh(eid, share)
+                .set_threshold()
+                .enforce_reliable_broadcast(false)
+                .start(&mut party_rng, party)
+                .await
+        }
+    })
+    .unwrap()
+    .expect_ok()
+    .into_vec()
+}
+
+// ===== Non-threshold tests =====
+
+#[test]
+fn non_threshold_refresh_preserves_secret_n3() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let n = 3u16;
+
+    let old_shares = run_non_threshold_keygen::<Secp256k1>(&mut rng, n);
+    let old_pk = old_shares[0].shared_public_key;
+
+    let old_sk = reconstruct_secret_key(&old_shares).unwrap();
+    assert_eq!(Point::generator() * &old_sk, old_pk);
+
+    let new_shares = run_non_threshold_refresh(&mut rng, &old_shares);
+
+    // Public key unchanged
+    for share in &new_shares {
+        assert_eq!(share.shared_public_key, old_pk);
+    }
+
+    // Secret key unchanged
+    let new_sk = reconstruct_secret_key(&new_shares).unwrap();
+    assert_eq!(Point::generator() * &new_sk, old_pk);
+
+    // Individual shares DID change
+    for (old, new) in old_shares.iter().zip(&new_shares) {
+        assert_ne!(
+            Point::<Secp256k1>::generator() * &old.x,
+            Point::generator() * &new.x,
+            "share {} did not change after refresh",
+            old.i
+        );
+    }
+
+    // Public shares changed but still consistent
+    for (i, share) in new_shares.iter().enumerate() {
+        assert_eq!(
+            Point::<Secp256k1>::generator() * &share.x,
+            share.public_shares[i],
+            "public share mismatch at index {}",
+            i
+        );
+    }
+}
+
+#[test]
+fn non_threshold_refresh_multiple_rounds_n3() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let n = 3u16;
+
+    let shares = run_non_threshold_keygen::<Secp256k1>(&mut rng, n);
+    let pk = shares[0].shared_public_key;
+    let original_sk = reconstruct_secret_key(&shares).unwrap();
+
+    let shares = run_non_threshold_refresh(&mut rng, &shares);
+    assert_eq!(shares[0].shared_public_key, pk);
+
+    let shares = run_non_threshold_refresh(&mut rng, &shares);
+    assert_eq!(shares[0].shared_public_key, pk);
+
+    let shares = run_non_threshold_refresh(&mut rng, &shares);
+    assert_eq!(shares[0].shared_public_key, pk);
+
+    let final_sk = reconstruct_secret_key(&shares).unwrap();
+    assert_eq!(
+        Point::<Secp256k1>::generator() * &final_sk,
+        Point::generator() * &original_sk,
+    );
+}
+
+#[test]
+fn non_threshold_refresh_n5() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let n = 5u16;
+
+    let old_shares = run_non_threshold_keygen::<Secp256k1>(&mut rng, n);
+    let pk = old_shares[0].shared_public_key;
+
+    let new_shares = run_non_threshold_refresh(&mut rng, &old_shares);
+
+    let new_sk = reconstruct_secret_key(&new_shares).unwrap();
+    assert_eq!(Point::generator() * &new_sk, pk);
+}
+
+// ===== Threshold tests =====
+
+#[test]
+fn threshold_refresh_preserves_secret_t2n3() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let (t, n) = (2u16, 3u16);
+
+    let old_shares = run_threshold_keygen::<Secp256k1>(&mut rng, t, n);
+    let pk = old_shares[0].shared_public_key;
+
+    let old_sk = reconstruct_secret_key(&old_shares[..usize::from(t)]).unwrap();
+    assert_eq!(Point::generator() * &old_sk, pk);
+
+    let new_shares = run_threshold_refresh(&mut rng, &old_shares);
+
+    for share in &new_shares {
+        assert_eq!(share.shared_public_key, pk);
+    }
+
+    assert_eq!(new_shares[0].min_signers(), t);
+
+    let new_sk = reconstruct_secret_key(&new_shares[..usize::from(t)]).unwrap();
+    assert_eq!(Point::generator() * &new_sk, pk);
+
+    for (old, new) in old_shares.iter().zip(&new_shares) {
+        assert_ne!(
+            Point::<Secp256k1>::generator() * &old.x,
+            Point::generator() * &new.x,
+            "threshold share {} did not change",
+            old.i
+        );
+    }
+
+    assert_eq!(new_shares[0].vss_setup, old_shares[0].vss_setup);
+}
+
+#[test]
+fn threshold_refresh_multiple_rounds_t2n3() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let (t, n) = (2u16, 3u16);
+
+    let shares = run_threshold_keygen::<Secp256k1>(&mut rng, t, n);
+    let pk = shares[0].shared_public_key;
+
+    let shares = run_threshold_refresh(&mut rng, &shares);
+    let shares = run_threshold_refresh(&mut rng, &shares);
+    let shares = run_threshold_refresh(&mut rng, &shares);
+
+    let sk = reconstruct_secret_key(&shares[..usize::from(t)]).unwrap();
+    assert_eq!(Point::generator() * &sk, pk);
+}
+
+#[test]
+fn threshold_refresh_t3n5() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let (t, n) = (3u16, 5u16);
+
+    let old_shares = run_threshold_keygen::<Secp256k1>(&mut rng, t, n);
+    let pk = old_shares[0].shared_public_key;
+
+    let new_shares = run_threshold_refresh(&mut rng, &old_shares);
+
+    let sk_012 = reconstruct_secret_key(&new_shares[0..3]).unwrap();
+    assert_eq!(Point::generator() * &sk_012, pk);
+
+    let sk_234 = reconstruct_secret_key(&new_shares[2..5]).unwrap();
+    assert_eq!(Point::generator() * &sk_234, pk);
+}
+
+// ===== Cross-epoch security tests =====
+
+#[test]
+fn old_shares_invalid_after_refresh_non_threshold() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let n = 3u16;
+
+    let old_shares = run_non_threshold_keygen::<Secp256k1>(&mut rng, n);
+    let new_shares = run_non_threshold_refresh(&mut rng, &old_shares);
+
+    // Mixing old and new shares should NOT reconstruct correctly.
+    let mixed_sum: Point<Secp256k1> = Point::generator() * &old_shares[0].x
+        + Point::generator() * &new_shares[1].x
+        + Point::generator() * &new_shares[2].x;
+
+    assert_ne!(
+        mixed_sum, old_shares[0].shared_public_key,
+        "mixed old+new shares should not reconstruct the secret"
+    );
+}
+
+// ===== Consistency tests =====
+
+#[test]
+fn refresh_public_share_consistency() {
+    use generic_ec::curves::Secp256k1;
+
+    let mut rng = DevRng::new();
+    let n = 3u16;
+
+    let old = run_non_threshold_keygen::<Secp256k1>(&mut rng, n);
+    let new_shares = run_non_threshold_refresh(&mut rng, &old);
+
+    for i in 0..n {
+        for j in 0..n {
+            assert_eq!(
+                new_shares[usize::from(i)].public_shares,
+                new_shares[usize::from(j)].public_shares,
+                "parties {} and {} disagree on public shares",
+                i,
+                j
+            );
+        }
+    }
+}

--- a/tests/tests/it/main.rs
+++ b/tests/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod key_refresh;
+mod key_share_refresh;
 mod keygen;
 mod old_shares;
 mod pipeline;


### PR DESCRIPTION
# Implement Key Refresh protocol (Fixes #162)

## Description

This PR implements the Key Share Refresh protocol as requested in #162, ensuring the long-term security of the secret key by updating individual key shares without changing the underlying secret key. 

The implementation covers:
1. **Non-Threshold (n-out-of-n)**: Compliant with Figure 7 of the CGGMP24 paper. Uses a zero-sum vector trick where each party distributes randomly sampled scalars summing to zero. Includes P2P unicast exchange and exact Feldman VSS verification over the $G$ curve, completing with a valid Schnorr proof of knowledge of the new secret share.
2. **Threshold (t-out-of-n)**: Compliant with Appendix F.1.1. Employs zero-sharing polynomials leveraging identical messaging rounds and evaluations but correctly isolating degree-$t-1$ bounds across public VSS polynomials.

## Key Changes
- Extracts the refresh logic out to `cggmp24-keygen/src/key_refresh_non_threshold.rs` and `cggmp24-keygen/src/key_refresh_threshold.rs`.
- Decouples refresh errors from `Bug`/`KeygenError` via separate `RefreshBug` and `RefreshAborted` enums to keep upstream Keygen cleaner.
- Ensures all new algorithms use the correct `generic-ec` 0.5 primitives (e.g., using `*secret_scalar.as_ref()` for Scalar bounds and `.value(&Scalar::zero())` without trait ambiguity).
- Both entry points and builders are re-exported into the main `cggmp24` crate alongside Keygen variants.
- Comprehensive integration tests at `tests/tests/it/key_share_refresh.rs` checking validity mapping across multiple rounds, unaltered secrets with altered shares, threshold min-signer limits, and cross-epoch share incompatibility.

This provides the core `cggmp24::keygen::key_refresh` functionality as requested, without the legacy aux info elements intermingled into these modules.
