### PR TITLE
docs: fix broken links to spec pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ There are other (small) differences in the implementation compared to the origin
 they are all documented in [the spec].
 
 [CGGMP24]: https://ia.cr/2021/060
-[the spec]: https://lfdt-lockness.github.io/cggmp24/cggmp24-spec.pdf
+[the spec]: https://lfdt-lockness.github.io/cggmp21/cggmp21-spec.pdf
 [security guidelines]: #security-guidelines
 [slip10]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -295,7 +295,7 @@
 //! they are all documented in [the spec].
 //!
 //! [CGGMP24]: https://ia.cr/2021/060
-//! [the spec]: https://lfdt-lockness.github.io/cggmp24/cggmp24-spec.pdf
+//! [the spec]: https://lfdt-lockness.github.io/cggmp21/cggmp21-spec.pdf
 //! [security guidelines]: #security-guidelines
 //! [slip10]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/spec/README.md
+++ b/spec/README.md
@@ -5,6 +5,6 @@ DKG and threshold signing protocols. It documents in great details each protocol
 used optimizations, differences compared to the original paper published on 
 [ePrint:2021/060](https://eprint.iacr.org/2021/060).
 
-Compiled version of the specs is available [here](https://lfdt-lockness.github.io/cggmp21/cggmp24-spec.pdf).
+Compiled version of the specs is available [here](https://lfdt-lockness.github.io/cggmp21/cggmp21-spec.pdf).
 
 [dfns-cggmp24]: https://github.com/LFDT-Lockness/cggmp21


### PR DESCRIPTION
Fixes #174 

The links pointing to `cggmp24-spec.pdf` in the `cggmp21` repository were broken because the compiled spec is actually hosted at `cggmp21-spec.pdf`. 

This PR corrects the links in:
- `README.md`
- `spec/README.md`
- `cggmp24/src/lib.rs`

All commits have been GPG signed and include the DCO `Signed-off-by` line as per the contributing guidelines.
