### PR TITLE
docs: fix typo compatability -> compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [HD wallets support](#hd-wallets-support)
 - [SPOF code: Key Import and Export](#spof-code-key-import-and-export)
 - [Big integer implementation](#big-integer-implementation)
-- [no\_std compatability](#no_std-compatability)
+- [no\_std compatibility](#no_std-compatibility)
 - [Differences between the implementation and CGGMP24](#differences-between-the-implementation-and-cggmp24)
 - [Timing attacks](#timing-attacks)
 - [Join us in Discord!](#join-us-in-discord)
@@ -244,7 +244,7 @@ some applications by several times, but requires an LGPL dependency
 - To use num-bigint, select the feature `backend-num-bigint` (selected as
 **default** feature)
 
-## no\_std compatability
+## no\_std compatibility
 
 Every crate in this project is compatible with no\_std, provided that
 `num-bigint` backend is chosen. The presence of `alloc` is still required. This

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -267,7 +267,7 @@
 //! - To use num-bigint, select the feature `backend-num-bigint` (selected as
 //! **default** feature)
 //!
-//! ## no\_std compatability
+//! ## no\_std compatibility
 //!
 //! Every crate in this project is compatible with no\_std, provided that
 //! `num-bigint` backend is chosen. The presence of `alloc` is still required. This

--- a/docs/toc-cggmp24.md
+++ b/docs/toc-cggmp24.md
@@ -12,7 +12,7 @@
 - [HD wallets support](#hd-wallets-support)
 - [SPOF code: Key Import and Export](#spof-code-key-import-and-export)
 - [Big integer implementation](#big-integer-implementation)
-- [no\_std compatability](#no_std-compatability)
+- [no\_std compatibility](#no_std-compatibility)
 - [Differences between the implementation and CGGMP24](#differences-between-the-implementation-and-cggmp24)
 - [Timing attacks](#timing-attacks)
 - [Join us in Discord!](#join-us-in-discord)


### PR DESCRIPTION
Fixes #181

Corrected the misspelled "compatability" to "compatibility" across the documentation headers.
