### PR TITLE
Fix deploy pages workflow and the link to the spec

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
   deploy_pages:
     runs-on: ubuntu-latest
     needs: [build_pdf, build_docs]
-    if: github.ref == 'refs/heads/m'
+    if: github.ref == 'refs/heads/cggmp24/m'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ There are other (small) differences in the implementation compared to the origin
 they are all documented in [the spec].
 
 [CGGMP24]: https://ia.cr/2021/060
-[the spec]: https://lfdt-lockness.github.io/cggmp24/cggmp24-spec.pdf
+[the spec]: https://lfdt-lockness.github.io/cggmp21/cggmp24-spec.pdf
 [security guidelines]: #security-guidelines
 [slip10]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -295,7 +295,7 @@
 //! they are all documented in [the spec].
 //!
 //! [CGGMP24]: https://ia.cr/2021/060
-//! [the spec]: https://lfdt-lockness.github.io/cggmp24/cggmp24-spec.pdf
+//! [the spec]: https://lfdt-lockness.github.io/cggmp21/cggmp24-spec.pdf
 //! [security guidelines]: #security-guidelines
 //! [slip10]: https://github.com/satoshilabs/slips/blob/master/slip-0010.md
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki


### PR DESCRIPTION
note: link should work after PR is merged. We need GH pages deploy to work first (it's been broken since the cggmp24 update)

Closes #174