### PR TITLE
fix: use generic security level in aux precompute instead of hardcoded SecurityLevel128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,19 @@ num-bigint.opt-level = 3
 num-traits.opt-level = 3
 num-integer.opt-level = 3
 glass_pumpkin.opt-level = 3
+
+# Enable debug assertions for workspace packages in release builds so that
+# debug_assert! calls in library code fire during `cargo test --release`.
+# Note: these overrides only apply within this workspace — binaries that
+# depend on these crates externally are not affected.
+[profile.release.package.cggmp24]
+debug-assertions = true
+
+[profile.release.package.cggmp24-keygen]
+debug-assertions = true
+
+[profile.release.package.key-share]
+debug-assertions = true
+
+[profile.release.package.paillier-zk]
+debug-assertions = true

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -242,9 +242,7 @@ impl PrecomputedKeyShares {
                         crt: None,
                     };
                     params.precompute_crt(&aux.hat_p, &aux.hat_q).unwrap();
-                    params
-                        .precompute_multiexp_table::<cggmp24::security_level::SecurityLevel128>()
-                        .unwrap();
+                    params.precompute_multiexp_table::<L>().unwrap();
                     params
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
Closes #185 

## Problem

`get_aux_inner` in `tests/src/lib.rs` calls `precompute_multiexp_table` with a hardcoded `SecurityLevel128`, ignoring the generic `L` parameter already in scope on the function signature.

This causes all `secp384r1` tests to fail because that curve uses `SecurityLevel192` (via the `CurveParams` trait impl at line 509), creating a type mismatch during aux info precomputation. The bug was silent because CI runs `cargo test --release`, which compiles out all `debug_assert!` calls — so no assertion fired to catch it.

## Fix

**1. One-line bug fix** (`tests/src/lib.rs`):
```diff
-  .precompute_multiexp_table::<cggmp24::security_level::SecurityLevel128>()
+  .precompute_multiexp_table::<L>()
```

**2. Enable debug assertions in release test builds** (`Cargo.toml`):

Added `[profile.release.package.*]` overrides so `debug_assert!` calls inside workspace library code fire during `cargo test --release`, as CI does. Third-party dependencies are unaffected.

```toml
[profile.release.package.cggmp24]
debug-assertions = true

[profile.release.package.cggmp24-keygen]
debug-assertions = true

[profile.release.package.key-share]
debug-assertions = true

[profile.release.package.paillier-zk]
debug-assertions = true
```

This ensures existing `debug_assert!` guards in `paillier-zk`, `key-share`, `cggmp24-keygen`, and `cggmp24/src/signing.rs` will catch invariant violations in future CI runs.

## Impact

- Fixes all `secp384r1` signing tests
- No behavioral change for `secp256k1`, `secp256r1`, or `stark`
- Prevents silent regressions of this class in CI going forward
---
