### PR TITLE
Docs: fix stale key-share version in no_std example

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ cargo file should look like this:
 ```toml
 cggmp24 = { version = "0.7", default-features = false, features = ["no_std", "backend-num-bigint"] }
 cggmp24-keygen = { version = "0.7", default-features = false }
-key-share = { version = "0.6", default-features = false }
+key-share = { version = "0.7", default-features = false }
 ```
 
 ## Differences between the implementation and CGGMP24

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -281,7 +281,7 @@
 //! ```toml
 //! cggmp24 = { version = "0.7", default-features = false, features = ["no_std", "backend-num-bigint"] }
 //! cggmp24-keygen = { version = "0.7", default-features = false }
-//! key-share = { version = "0.6", default-features = false }
+//! key-share = { version = "0.7", default-features = false }
 //! ```
 //!
 //! ## Differences between the implementation and CGGMP24


### PR DESCRIPTION
Fixes #192

Summary
Updates the `no_std` dependency example to use the current `key-share` release line.

The docs currently show:

```toml
key-share = { version = "0.6", default-features = false }
```

ping @maurges @survived 