### PR TITLE
tests: add secp384r1 external verifier using p384 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +365,7 @@ dependencies = [
  "hex",
  "include_dir",
  "lazy_static",
+ "p384",
  "pin-project",
  "rand",
  "rand_dev",
@@ -719,6 +726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -740,6 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -753,6 +762,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -785,6 +808,9 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -1270,6 +1296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,8 +1726,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1759,6 +1796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1859,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "platforms"
@@ -2258,6 +2314,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -2391,6 +2448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2481,16 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stark-curve"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "1.4"
 
 # external verifiers
 secp256k1 = { version = "0.26", features = ["global-context", "bitcoin-hashes"] }
+p384 = { version = "0.13", features = ["ecdsa"] }
 starknet-crypto = { version = "0.6" }
 starknet-core = { version = "0.6" }
 starknet-accounts = { version = "0.5" }

--- a/tests/src/external_verifier.rs
+++ b/tests/src/external_verifier.rs
@@ -25,7 +25,7 @@ impl<E: Curve> ExternalVerifier<E> for Noop {
 
 pub mod blockchains {
     use anyhow::Context;
-    use cggmp24::supported_curves::{Secp256k1, Stark};
+    use cggmp24::supported_curves::{Secp256k1, Secp384r1, Stark};
 
     use crate::{convert_stark_scalar, external_verifier::ExternalVerifier};
 
@@ -51,6 +51,29 @@ pub mod blockchains {
             signature
                 .verify(&message, &public_key)
                 .context("invalid siganture")
+        }
+    }
+
+    /// Verifies ECDSA/P-384 signature using the RustCrypto `p384` crate
+    pub struct NistP384;
+
+    impl ExternalVerifier<Secp384r1> for NistP384 {
+        fn verify(
+            public_key: &generic_ec::Point<Secp384r1>,
+            signature: &cggmp24::signing::Signature<Secp384r1>,
+            message: &[u8],
+        ) -> anyhow::Result<()> {
+            use p384::ecdsa::signature::Verifier as _;
+
+            let vk = p384::ecdsa::VerifyingKey::from_sec1_bytes(&public_key.to_bytes(true))
+                .context("invalid public key")?;
+
+            let mut sig_bytes = [0u8; 96];
+            signature.write_to_slice(&mut sig_bytes);
+            let sig = p384::ecdsa::Signature::try_from(sig_bytes.as_slice())
+                .context("malformed signature")?;
+
+            vk.verify(message, &sig).context("invalid signature")
         }
     }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -507,7 +507,7 @@ impl CurveParams for cggmp24::supported_curves::Secp256r1 {
 }
 
 impl CurveParams for cggmp24::supported_curves::Secp384r1 {
-    type ExVerifier = external_verifier::Noop;
+    type ExVerifier = external_verifier::blockchains::NistP384;
     type SecurityLevel = cggmp24::security_level::SecurityLevel192;
     type Digest = sha2::Sha384;
     type DigestOutSize = <Self::Digest as digest::OutputSizeUser>::OutputSize;


### PR DESCRIPTION
## What

Replaces the no-op external verifier for `Secp384r1` with a real cross-check against RustCrypto's [`p384`](https://crates.io/crates/p384) crate.

## Why

The `signing_works::secp384r1::*` test suite already calls `E::ExVerifier::verify(...)` after every signing run, but until now it used `Noop` — so the signature bytes were never validated by an independent implementation. Adding a real verifier here closes that gap and gives confidence that cggmp24's P-384 signatures are compatible with the wider RustCrypto ecosystem.

## How

- Added `p384 = { version = "0.13", features = ["ecdsa"] }` to `tests/Cargo.toml`.
- Added `NistP384` struct in `tests/src/external_verifier.rs` implementing `ExternalVerifier<Secp384r1>`:
  - Converts the SEC1-encoded public key to `p384::ecdsa::VerifyingKey`.
  - Writes the cggmp24 signature as 96 bytes (`r ‖ s`) and parses into `p384::ecdsa::Signature`.
  - Calls `VerifyingKey::verify(message, &sig)`, which hashes with SHA-384 internally — matching `Secp384r1`'s `type Digest = sha2::Sha384`.
- Updated `CurveParams for Secp384r1` in `tests/src/lib.rs` to use `NistP384` instead of `Noop`.

All existing tests compile and pass locally (non-secp384r1 suites). The secp384r1 signing tests themselves have a pre-existing failure unrelated to this change (`PiEncElg` max-exponent-size check fails for 384-bit scalars).