### PR TITLE
validate parameters before protocol start

### DIFF
--- a/cggmp24-keygen/src/lib.rs
+++ b/cggmp24-keygen/src/lib.rs
@@ -218,6 +218,8 @@ where
         R: RngCore + CryptoRng,
         M: Mpc<ProtocolMessage = non_threshold::Msg<E, L, D>>,
     {
+        validate_keygen_params(self.i, self.n)?;
+
         non_threshold::run_keygen(
             self.tracer,
             self.i,
@@ -262,6 +264,8 @@ where
         R: RngCore + CryptoRng,
         M: Mpc<ProtocolMessage = threshold::Msg<E, L, D>>,
     {
+        validate_threshold_keygen_params(self.i, self.optional_t.0, self.n)?;
+
         threshold::run_threshold_keygen(
             self.tracer,
             self.i,
@@ -354,6 +358,14 @@ enum KeygenAborted {
 enum Bug {
     #[displaydoc("resulting key share is not valid")]
     InvalidKeyShare(#[cfg_attr(feature = "std", source)] InvalidCoreShare),
+    #[displaydoc("number of parties is too small: n={n}")]
+    TooFewParties { n: u16 },
+    #[displaydoc("party index is out of range: i={i}, n={n}")]
+    PartyIndexOutOfRange { i: u16, n: u16 },
+    #[displaydoc("threshold is too small: t={t}")]
+    ThresholdTooSmall { t: u16 },
+    #[displaydoc("threshold is larger than number of parties: t={t}, n={n}")]
+    ThresholdTooLarge { t: u16, n: u16 },
     #[displaydoc("unexpected zero value")]
     NonZeroScalar,
     #[cfg(feature = "hd-wallet")]
@@ -363,6 +375,27 @@ enum Bug {
     ZeroShare,
     #[displaydoc("shared public key is zero - probability of that is negligible")]
     ZeroPk,
+}
+
+fn validate_keygen_params(i: u16, n: u16) -> Result<(), KeygenError> {
+    if n < 2 {
+        return Err(Bug::TooFewParties { n }.into());
+    }
+    if i >= n {
+        return Err(Bug::PartyIndexOutOfRange { i, n }.into());
+    }
+    Ok(())
+}
+
+fn validate_threshold_keygen_params(i: u16, t: u16, n: u16) -> Result<(), KeygenError> {
+    validate_keygen_params(i, n)?;
+    if t < 2 {
+        return Err(Bug::ThresholdTooSmall { t }.into());
+    }
+    if t > n {
+        return Err(Bug::ThresholdTooLarge { t, n }.into());
+    }
+    Ok(())
 }
 
 /// Distributed key generation protocol

--- a/tests/tests/it/keygen.rs
+++ b/tests/tests/it/keygen.rs
@@ -138,6 +138,62 @@ where
     validate_keygen_output::<E, Hd>(&mut rng, &key_shares);
 }
 
+#[test]
+fn non_threshold_keygen_rejects_invalid_params_before_networking() {
+    use cggmp24::supported_curves::Secp256k1;
+
+    type Msg = cggmp24::keygen::NonThresholdMsg<
+        Secp256k1,
+        cggmp24::security_level::SecurityLevel128,
+        sha2::Sha256,
+    >;
+
+    for (i, n) in [(0, 1), (2, 2)] {
+        let eid = ExecutionId::new(b"invalid non-threshold keygen params");
+        let mut rng = DevRng::new();
+        let incoming = futures::stream::pending::<
+            Result<round_based::Incoming<Msg>, std::convert::Infallible>,
+        >();
+        let outgoing = futures::sink::drain::<round_based::Outgoing<Msg>>();
+        let party = round_based::MpcParty::connected((incoming, outgoing));
+
+        let result = futures::executor::block_on(
+            cggmp24::keygen::<Secp256k1>(eid, i, n).start(&mut rng, party),
+        );
+
+        assert!(result.is_err());
+    }
+}
+
+#[test]
+fn threshold_keygen_rejects_invalid_params_before_networking() {
+    use cggmp24::supported_curves::Secp256k1;
+
+    type Msg = cggmp24::keygen::ThresholdMsg<
+        Secp256k1,
+        cggmp24::security_level::SecurityLevel128,
+        sha2::Sha256,
+    >;
+
+    for (i, t, n) in [(0, 1, 1), (0, 1, 3), (0, 4, 3), (3, 2, 3)] {
+        let eid = ExecutionId::new(b"invalid threshold keygen params");
+        let mut rng = DevRng::new();
+        let incoming = futures::stream::pending::<
+            Result<round_based::Incoming<Msg>, std::convert::Infallible>,
+        >();
+        let outgoing = futures::sink::drain::<round_based::Outgoing<Msg>>();
+        let party = round_based::MpcParty::connected((incoming, outgoing));
+
+        let result = futures::executor::block_on(
+            cggmp24::keygen::<Secp256k1>(eid, i, n)
+                .set_threshold(t)
+                .start(&mut rng, party),
+        );
+
+        assert!(result.is_err());
+    }
+}
+
 fn validate_keygen_output<E: generic_ec::Curve, Hd: cggmp24_tests::OptionalHd<E>>(
     rng: &mut impl rand::RngCore,
     key_shares: &[cggmp24::IncompleteKeyShare<E>],


### PR DESCRIPTION
Summary: related to #151
Adds upfront validation for key generation parameters before entering the DKG protocol runner.

Changes:
Non-threshold keygen now rejects n < 2.
Non-threshold keygen now rejects i >= n.
Threshold keygen now also rejects t < 2.
Threshold keygen now also rejects t > n.
Invalid inputs now fail before networking setup, random sampling, or protocol execution.

Tests:
Added tests that run keygen with invalid parameters using pending incoming messages and drain outgoing messages. The tests pass only if validation happens before the protocol waits on networking.

Validation:
cargo fmt --all -- --check
cargo check --workspace --exclude cggmp24-tests
cargo test -p cggmp24-tests keygen_rejects_invalid_params_before_networking
git diff --check