### PR TITLE
fix(key-refresh): validate aux-gen input parameters before protocol start

### DIFF
--- a/cggmp24/src/key_refresh.rs
+++ b/cggmp24/src/key_refresh.rs
@@ -228,12 +228,36 @@ enum Reason {
     IoError(#[source] IoError),
     #[error("internal error")]
     InternalError(#[from] Bug),
+    #[error("invalid arguments")]
+    InvalidArgs(#[source] InvalidArgs),
+}
+
+/// Invalid input parameters passed to the aux-gen protocol
+#[derive(Debug, Error)]
+pub enum InvalidArgs {
+    /// Number of parties `n` must be at least 2
+    #[error("number of parties n must be at least 2, got n={0}")]
+    TooFewParties(u16),
+    /// Party index `i` must satisfy `i < n`
+    #[error("party index i={i} is out of range for n={n} parties")]
+    PartyIndexOutOfRange {
+        /// Party index
+        i: u16,
+        /// Number of parties
+        n: u16,
+    },
+}
+
+impl From<InvalidArgs> for KeyRefreshError {
+    fn from(e: InvalidArgs) -> Self {
+        KeyRefreshError(Reason::InvalidArgs(e))
+    }
 }
 
 /// Unexpected error in operation not caused by other parties
 #[derive(Debug, Error)]
 enum Bug {
-    #[error("Invalid key share geenrated")]
+    #[error("invalid key share generated")]
     InvalidShareGenerated(#[source] crate::key_share::InvalidKeyShare),
     #[error("couldn't prove a pi mod statement")]
     PiMod(#[source] paillier_zk::Error),

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -165,6 +165,13 @@ where
     L: SecurityLevel,
     D: Digest + Clone + 'static,
 {
+    if n < 2 {
+        return Err(super::InvalidArgs::TooFewParties(n).into());
+    }
+    if i >= n {
+        return Err(super::InvalidArgs::PartyIndexOutOfRange { i, n }.into());
+    }
+
     tracer.protocol_begins();
 
     tracer.stage("Retrieve auxiliary data");

--- a/tests/tests/it/key_refresh.rs
+++ b/tests/tests/it/key_refresh.rs
@@ -101,3 +101,51 @@ where
     sig.verify(&key_shares[0].core.shared_public_key, &message_to_sign)
         .expect("signature is not valid");
 }
+
+#[test]
+fn aux_gen_rejects_n_too_small() {
+    let mut rng = rand_dev::DevRng::new();
+    let eid: [u8; 32] = rand::Rng::gen(&mut rng);
+    let eid = cggmp24::ExecutionId::new(&eid);
+
+    type L = cggmp24::security_level::SecurityLevel128;
+    type D = sha2::Sha256;
+    type Msg = cggmp24::key_refresh::msg::Msg<D, L>;
+
+    let primes = cggmp24_tests::cached::PRIMES.iter::<L>().next().unwrap();
+    let incoming = futures::stream::pending::<
+        Result<round_based::Incoming<Msg>, std::convert::Infallible>,
+    >();
+    let outgoing = futures::sink::drain::<round_based::Outgoing<Msg>>();
+    let party = round_based::MpcParty::connected((incoming, outgoing));
+
+    let result = futures::executor::block_on(
+        cggmp24::aux_info_gen(eid, 0, 1, primes).start(&mut rng, party),
+    );
+
+    assert!(result.is_err(), "aux_gen with n=1 must fail before networking");
+}
+
+#[test]
+fn aux_gen_rejects_i_out_of_range() {
+    let mut rng = rand_dev::DevRng::new();
+    let eid: [u8; 32] = rand::Rng::gen(&mut rng);
+    let eid = cggmp24::ExecutionId::new(&eid);
+
+    type L = cggmp24::security_level::SecurityLevel128;
+    type D = sha2::Sha256;
+    type Msg = cggmp24::key_refresh::msg::Msg<D, L>;
+
+    let primes = cggmp24_tests::cached::PRIMES.iter::<L>().next().unwrap();
+    let incoming = futures::stream::pending::<
+        Result<round_based::Incoming<Msg>, std::convert::Infallible>,
+    >();
+    let outgoing = futures::sink::drain::<round_based::Outgoing<Msg>>();
+    let party = round_based::MpcParty::connected((incoming, outgoing));
+
+    let result = futures::executor::block_on(
+        cggmp24::aux_info_gen(eid, 3, 3, primes).start(&mut rng, party),
+    );
+
+    assert!(result.is_err(), "aux_gen with i >= n must fail before networking");
+}


### PR DESCRIPTION
## Summary

`aux_info_gen` accepted `i` and `n` without any upfront validation. Invalid inputs like `n < 2` or `i >= n` would fail deep in the networking layer with a confusing I/O error instead of a clear message.

## Changes
- **`cggmp24/src/key_refresh.rs`** — adds `InvalidArgs` error type with `TooFewParties` and `PartyIndexOutOfRange` variants; wires it into `KeyRefreshError`; fixes `"geenrated"` typo in `Bug::InvalidShareGenerated`
- **`cggmp24/src/key_refresh/aux_only.rs`** — adds guard checks at the top of `run_aux_gen` before any networking or crypto runs
- **`tests/tests/it/key_refresh.rs`** — adds two tests using `stream::pending` + `sink::drain` to prove validation fires before the protocol waits on networking

## Testing
```
cargo build --workspace
cargo test -p cggmp24-tests aux_gen_rejects
```

## Notes

- Same validation pattern as the keygen protocol; aux-gen was the remaining unguarded entry point.
- Issue scope was analysed thoroughly before implementing this fix.