### PR TITLE
Expose set_additive_shift on SigningBuilder for HMAC-based HD derivation

### DIFF
--- a/cggmp24/src/signing.rs
+++ b/cggmp24/src/signing.rs
@@ -479,6 +479,22 @@ where
         }
     }
 
+    /// Sets the additive shift directly as a raw scalar.
+    ///
+    /// The shift is added to the reconstructed secret during signing,
+    /// producing a signature for `shared_public_key + G * shift`.
+    /// Only party `i == 0` adds the shift to their secret share;
+    /// all parties update the public key commitment.
+    ///
+    /// This is useful for HD-wallet-like derivation schemes (e.g., BRC-42)
+    /// where the shift is computed externally rather than via
+    /// [`set_derivation_path`](Self::set_derivation_path).
+    #[cfg(feature = "hd-wallet")]
+    pub fn set_additive_shift(mut self, shift: Scalar<E>) -> Self {
+        self.additive_shift = Some(shift);
+        self
+    }
+
     /// Specifies HD derivation path
     ///
     /// ## Example


### PR DESCRIPTION
## Expose `set_additive_shift` on `SigningBuilder` for HMAC-based HD derivation

### Motivation

Bitcoin SV wallets standardize on **BRC-42** key derivation, which derives child keys via:

```
child_priv = root_priv + HMAC-SHA256(ECDH(counterparty_pub, root_priv), invoice_string)
```

This is an additive shift, but the shift scalar is computed externally rather than via SLIP-10 path traversal. The existing public API `set_derivation_path` / `set_derivation_path_with_algo` covers BIP-32-style integer paths, but BRC-42 uses HMAC-SHA256 with structured invoice strings (`{security_level}-{protocol_id.to_lowercase().trim()}-{key_id}`). There's no public path to inject an externally-computed `Scalar<E>` shift today.

### Change

Adds a 4-line public method `set_additive_shift(shift: Scalar<E>) -> Self` on `SigningBuilder`, behind the existing `#[cfg(feature = "hd-wallet")]` gate.

```rust
#[cfg(feature = "hd-wallet")]
pub fn set_additive_shift(mut self, shift: Scalar<E>) -> Self {
    self.additive_shift = Some(shift);
    self
}
```

The `additive_shift` field already exists on `SigningBuilder` and is consumed downstream in the signing protocol. `set_derivation_path` writes to this same field via the SLIP-10 derivation. This PR just exposes a way to set it directly with a caller-computed scalar.

### Use case

Two independent BSV MPC implementations (Calhoun's `bsv-mpc`, Binary's `rust-mpc`) currently maintain a `[patch.crates-io]` directive pointing at a fork to access this functionality. Merging upstream removes that maintenance burden for both. The change has been running in those forks since 2026-03 with no protocol-correctness issues observed.

### What this PR doesn't change

- The internal consumption of `additive_shift` — unchanged from the SLIP-10 path.
- Any other API or behavior — purely additive.
- Test coverage — happy to add a doc-comment example showing BRC-42 usage if reviewers want.

### Related

Two BSV partnership spec docs reference this patch:
- ADR-0001 (cggmp24 pin past CVE-2025): https://github.com/B1nary-Calhoun-Partnership/MPC-Spec/blob/main/decisions/0001-cggmp24-pin-past-cve-2025.md
- §01-cggmp24-pin: https://github.com/B1nary-Calhoun-Partnership/MPC-Spec/blob/main/01-cggmp24-pin.md

Happy to add tests, doc examples, or reshape the API if reviewers prefer a different signature.