### PR TITLE
fix(paillier-zk): validate nonce is in Z_N* before encrypt_with in verifiers

### DIFF
--- a/paillier-zk/src/paillier_affine_operation_in_range.rs
+++ b/paillier-zk/src/paillier_affine_operation_in_range.rs
@@ -406,6 +406,15 @@ pub mod interactive {
             aux.is_in_mult_group(&commitment.t),
         )?;
 
+        fail_if(
+            InvalidProofReason::RangeCheck(17),
+            proof.w.in_mult_group_of(data.key_j.n()),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(18),
+            proof.w_y.in_mult_group_of(data.key_i.n()),
+        )?;
+
         // Verify statement
         {
             let lhs = {

--- a/paillier-zk/src/paillier_encryption_in_range.rs
+++ b/paillier-zk/src/paillier_encryption_in_range.rs
@@ -282,6 +282,10 @@ pub mod interactive {
                 &(&aux.rsa_modulo * (Integer::one() << (security.l + security.epsilon + 1))),
             ),
         )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(7),
+            proof.z2.in_mult_group_of(data.key.n()),
+        )?;
 
         {
             let lhs = data

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -295,6 +295,10 @@ pub mod interactive {
             InvalidProofReason::RangeCheck(4),
             commitment.d.in_mult_group_of(data.key.nn()),
         )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(5),
+            proof.z2.in_mult_group_of(data.key.n()),
+        )?;
 
         // Verify statement
         {


### PR DESCRIPTION
Closes #136 (partially).

As discussed in #136, the verifiers in `paillier_encryption_in_range`, `paillier_encryption_in_range_with_el_gamal`, and `paillier_affine_operation_in_range` were passing nonce fields (`z2`, `w`, `w_y`) into `encrypt_with` without first checking they belong to the Paillier multiplicative group `Z_N*`. A malicious prover could send an arbitrarily large nonce, triggering expensive Paillier computation before the invalid input is rejected.

This PR adds upfront `in_mult_group_of` checks on those fields before the `encrypt_with` calls, consistent with how other input fields are already validated in these verifiers.