### PR TITLE
Update Discord link to LFDT-wide invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,4 +69,4 @@ it following the procedure described in [SECURITY.md](./SECURITY.md).
 
 Feel free to reach out to us [in Discord] as well.
 
-[in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+[in Discord]: https://discord.com/invite/hyperledger

--- a/README.md
+++ b/README.md
@@ -289,6 +289,6 @@ don't do constant-time operations which gives us a significant performance boost
 ## Join us in Discord!
 Feel free to reach out to us [in Discord]!
 
-[in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+[in Discord]: https://discord.com/invite/hyperledger
 
 <!-- cargo-rdme end -->

--- a/cggmp24/src/lib.rs
+++ b/cggmp24/src/lib.rs
@@ -312,7 +312,7 @@
 //! ## Join us in Discord!
 //! Feel free to reach out to us [in Discord]!
 //!
-//! [in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+//! [in Discord]: https://discord.com/invite/hyperledger
 
 #![allow(
     non_snake_case,

--- a/paillier-zk/README.md
+++ b/paillier-zk/README.md
@@ -3,7 +3,7 @@
 [![Crates io](https://img.shields.io/crates/v/paillier-zk.svg)](https://crates.io/crates/paillier-zk)
 [![Discord](https://img.shields.io/discord/905194001349627914?logo=discord&logoColor=ffffff&label=Discord)][in Discord]
 
-[in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+[in Discord]: https://discord.com/invite/hyperledger
 
 # paillier-zk
 


### PR DESCRIPTION
Many people have reported that the Discord link we use doesn't work for them. This link should work.