### PR TITLE
fix(paillier-zk): validate proof bounds before modular exponentiation

### DIFF
--- a/paillier-zk/src/no_small_factor.rs
+++ b/paillier-zk/src/no_small_factor.rs
@@ -289,6 +289,33 @@ pub mod interactive {
                 .map_err(|_| InvalidProofReason::Conversion)?;
             fail_if(InvalidProofReason::RangeCheck(5), n_bits >= 4 * security.l)?;
         }
+
+        let range = (Integer::from(1) << (security.l + security.epsilon)) * data.n_root;
+        fail_if(
+            InvalidProofReason::RangeCheck(12),
+            proof.z1.is_in_half_pm(&range),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(13),
+            proof.z2.is_in_half_pm(&range),
+        )?;
+
+        let aux_range = (Integer::from(1) << (security.l + security.epsilon + 1)) * &aux.rsa_modulo;
+        fail_if(
+            InvalidProofReason::RangeCheck(14),
+            proof.w1.is_in_half_pm(&aux_range),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(15),
+            proof.w2.is_in_half_pm(&aux_range),
+        )?;
+
+        let n_at_aux_range = aux_range * data.n;
+        fail_if(
+            InvalidProofReason::RangeCheck(16),
+            proof.v.is_in_half_pm(&n_at_aux_range),
+        )?;
+
         {
             let lhs = aux.combine(&proof.z1, &proof.w1)?;
             let p_to_e = aux.pow_mod(&commitment.p, challenge)?;
@@ -321,17 +348,6 @@ pub mod interactive {
                 aux.is_in_mult_group(&lhs),
             )?;
         }
-        let range = (Integer::from(1) << (security.l + security.epsilon)) * data.n_root;
-        // range check for z1
-        fail_if(
-            InvalidProofReason::RangeCheck(12),
-            proof.z1.is_in_half_pm(&range),
-        )?;
-        // range check for z2
-        fail_if(
-            InvalidProofReason::RangeCheck(13),
-            proof.z2.is_in_half_pm(&range),
-        )?;
 
         Ok(())
     }
@@ -405,6 +421,8 @@ pub mod non_interactive {
 
 #[cfg(test)]
 mod test {
+    use fast_paillier::backend::Integer;
+
     use crate::common::test::generate_blum_prime;
     use crate::common::InvalidProofReason;
 
@@ -485,6 +503,48 @@ mod test {
             .expect_err("proof should not pass");
         match r.reason() {
             InvalidProofReason::RangeCheck(12) => (),
+            e => panic!("Proof should not fail with {e:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_response() {
+        type D = sha2::Sha256;
+
+        let n_bitlen = 3072;
+        let security = super::SecurityParams {
+            l: 256,
+            epsilon: 512,
+        };
+
+        let mut rng = rand_dev::DevRng::new();
+        let p = generate_blum_prime(&mut rng, n_bitlen / 2);
+        let q = generate_blum_prime(&mut rng, n_bitlen / 2);
+        let n = &p * &q;
+        let n_root = n.sqrt_ref().unwrap();
+        let data = super::Data {
+            n: &n,
+            n_root: &n_root,
+        };
+
+        let aux = crate::common::test::aux(&mut rng);
+        let shared_state = "shared state";
+        let mut proof = super::non_interactive::prove::<D>(
+            &shared_state,
+            &aux,
+            data,
+            super::PrivateData { p: &p, q: &q },
+            &security,
+            &mut rng,
+        )
+        .unwrap();
+
+        proof.proof.w1 = Integer::one() << 10_000;
+
+        let r = super::non_interactive::verify::<D>(&shared_state, &aux, data, &security, &proof)
+            .expect_err("proof should not pass");
+        match r.reason() {
+            InvalidProofReason::RangeCheck(14) => (),
             e => panic!("Proof should not fail with {e:?}"),
         }
     }

--- a/paillier-zk/src/paillier_affine_operation_in_range.rs
+++ b/paillier-zk/src/paillier_affine_operation_in_range.rs
@@ -406,6 +406,36 @@ pub mod interactive {
             aux.is_in_mult_group(&commitment.t),
         )?;
 
+        fail_if(
+            InvalidProofReason::RangeCheck(15),
+            proof
+                .z1
+                .is_in_half_pm(&(Integer::one() << (security.l_x + security.epsilon))),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(16),
+            proof
+                .z2
+                .is_in_half_pm(&(Integer::one() << (security.l_y + security.epsilon))),
+        )?;
+        let aux_range = &aux.rsa_modulo * (Integer::one() << (security.l_x + security.epsilon + 1));
+        fail_if(
+            InvalidProofReason::RangeCheck(17),
+            proof.z3.is_in_half_pm(&aux_range),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(18),
+            proof.z4.is_in_half_pm(&aux_range),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(19),
+            proof.w.in_mult_group_of(data.key_j.n()),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(20),
+            proof.w_y.in_mult_group_of(data.key_i.n()),
+        )?;
+
         // Verify statement
         {
             let lhs = {
@@ -465,18 +495,6 @@ pub mod interactive {
             let rhs = (&commitment.f * t_to_e).modulo(&aux.rsa_modulo);
             fail_if_ne(InvalidProofReason::EqualityCheck(14), lhs, rhs)?;
         }
-        fail_if(
-            InvalidProofReason::RangeCheck(15),
-            proof
-                .z1
-                .is_in_half_pm(&(Integer::one() << (security.l_x + security.epsilon))),
-        )?;
-        fail_if(
-            InvalidProofReason::RangeCheck(16),
-            proof
-                .z2
-                .is_in_half_pm(&(Integer::one() << (security.l_y + security.epsilon))),
-        )?;
         Ok(())
     }
 
@@ -565,11 +583,16 @@ mod test {
     use crate::common::test::random_key;
     use crate::common::{IntegerExt, InvalidProofReason};
 
-    fn run<R: rand_core::RngCore + rand_core::CryptoRng, C: Curve, D: Digest>(
+    fn run_with_proof_mutation<
+        R: rand_core::RngCore + rand_core::CryptoRng,
+        C: Curve,
+        D: Digest,
+    >(
         rng: &mut R,
         security: super::SecurityParams,
         x: Integer,
         y: Integer,
+        mutate: impl FnOnce(&mut super::NiProof<C>),
     ) -> Result<(), crate::common::InvalidProof> {
         let dk0 = random_key(rng).unwrap();
         let dk1 = random_key(rng).unwrap();
@@ -606,10 +629,20 @@ mod test {
 
         let shared_state = "shared state";
 
-        let proof =
+        let mut proof =
             super::non_interactive::prove::<C, D>(&shared_state, &aux, data, pdata, &security, rng)
                 .unwrap();
+        mutate(&mut proof);
         super::non_interactive::verify::<C, D>(&shared_state, &aux, data, &security, &proof)
+    }
+
+    fn run<R: rand_core::RngCore + rand_core::CryptoRng, C: Curve, D: Digest>(
+        rng: &mut R,
+        security: super::SecurityParams,
+        x: Integer,
+        y: Integer,
+    ) -> Result<(), crate::common::InvalidProof> {
+        run_with_proof_mutation::<R, C, D>(rng, security, x, y, |_| {})
     }
 
     fn passing_test<C: Curve, D: Digest>() {
@@ -656,6 +689,25 @@ mod test {
         }
     }
 
+    fn failing_on_oversized_aux_response<C: Curve, D: Digest>() {
+        let mut rng = rand_dev::DevRng::new();
+        let security = super::SecurityParams {
+            l_x: 256,
+            l_y: 1280,
+            epsilon: 512,
+        };
+        let x = Integer::from_rng_half_pm(&mut rng, &(Integer::one() << security.l_x));
+        let y = Integer::from_rng_half_pm(&mut rng, &(Integer::one() << security.l_y));
+        let r = run_with_proof_mutation::<_, C, D>(&mut rng, security, x, y, |proof| {
+            proof.proof.z3 = Integer::one() << 10_000;
+        })
+        .expect_err("proof should not pass");
+        match r.reason() {
+            InvalidProofReason::RangeCheck(17) => (),
+            e => panic!("proof should not fail with: {e:?}"),
+        }
+    }
+
     #[test]
     fn passing_p256() {
         passing_test::<generic_ec::curves::Secp256r1, sha2::Sha256>()
@@ -667,6 +719,10 @@ mod test {
     #[test]
     fn failing_p256_mul() {
         failing_on_multiplicative::<generic_ec::curves::Secp256r1, sha2::Sha256>()
+    }
+    #[test]
+    fn failing_p256_oversized_aux_response() {
+        failing_on_oversized_aux_response::<generic_ec::curves::Secp256r1, sha2::Sha256>()
     }
 
     #[test]

--- a/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
+++ b/paillier-zk/src/paillier_encryption_in_range_with_el_gamal.rs
@@ -296,6 +296,23 @@ pub mod interactive {
             commitment.d.in_mult_group_of(data.key.nn()),
         )?;
 
+        fail_if(
+            InvalidProofReason::RangeCheck(9),
+            proof
+                .z1
+                .is_in_half_pm(&(Integer::one() << (security.l + security.epsilon))),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(10),
+            proof.z2.in_mult_group_of(data.key.n()),
+        )?;
+        fail_if(
+            InvalidProofReason::RangeCheck(11),
+            proof.z3.is_in_half_pm(
+                &(&aux.rsa_modulo * (Integer::one() << (security.l + security.epsilon + 1))),
+            ),
+        )?;
+
         // Verify statement
         {
             let lhs = data
@@ -331,13 +348,6 @@ pub mod interactive {
             };
             fail_if_ne(InvalidProofReason::EqualityCheck(8), lhs, rhs)?;
         }
-
-        fail_if(
-            InvalidProofReason::RangeCheck(9),
-            proof
-                .z1
-                .is_in_half_pm(&(Integer::one() << (security.l + security.epsilon))),
-        )?;
 
         Ok(())
     }
@@ -426,10 +436,11 @@ mod test {
 
     use crate::common::{IntegerExt, InvalidProofReason};
 
-    fn run_with<E: Curve, D: Digest>(
+    fn run_with_proof_mutation<E: Curve, D: Digest>(
         mut rng: &mut impl rand_core::CryptoRngCore,
         security: super::SecurityParams,
         plaintext: Integer,
+        mutate: impl FnOnce(&mut super::NiProof<E>),
     ) -> Result<(), crate::common::InvalidProof> {
         let aux = crate::common::test::aux(&mut rng);
 
@@ -452,10 +463,19 @@ mod test {
         };
 
         let shared_state = "shared state";
-        let proof =
+        let mut proof =
             super::non_interactive::prove::<E, D>(&shared_state, &aux, data, pdata, &security, rng)
                 .unwrap();
+        mutate(&mut proof);
         super::non_interactive::verify::<E, D>(&shared_state, &aux, data, &proof, &security)
+    }
+
+    fn run_with<E: Curve, D: Digest>(
+        rng: &mut impl rand_core::CryptoRngCore,
+        security: super::SecurityParams,
+        plaintext: Integer,
+    ) -> Result<(), crate::common::InvalidProof> {
+        run_with_proof_mutation::<E, D>(rng, security, plaintext, |_| {})
     }
 
     fn passing_test<C: Curve, D: Digest>() {
@@ -482,6 +502,23 @@ mod test {
         }
     }
 
+    fn failing_oversized_aux_response<C: Curve, D: Digest>() {
+        let mut rng = rand_dev::DevRng::new();
+        let security = super::SecurityParams {
+            l: 256,
+            epsilon: 512,
+        };
+        let plaintext = Integer::from_rng_half_pm(&mut rng, &(Integer::one() << security.l));
+        let r = run_with_proof_mutation::<C, D>(&mut rng, security, plaintext, |proof| {
+            proof.proof.z3 = Integer::one() << 10_000;
+        })
+        .expect_err("proof should not pass");
+        match r.reason() {
+            InvalidProofReason::RangeCheck(11) => (),
+            e => panic!("proof should not fail with: {e:?}"),
+        }
+    }
+
     #[test]
     fn passing_p256() {
         passing_test::<generic_ec::curves::Secp256r1, sha2::Sha256>()
@@ -489,6 +526,10 @@ mod test {
     #[test]
     fn failing_p256_add() {
         failing_test::<generic_ec::curves::Secp256r1, sha2::Sha256>()
+    }
+    #[test]
+    fn failing_p256_oversized_aux_response() {
+        failing_oversized_aux_response::<generic_ec::curves::Secp256r1, sha2::Sha256>()
     }
 
     #[test]


### PR DESCRIPTION
Fixes #209

The three affected verifiers in `paillier-zk` were running expensive modular exponentiations before they'd checked whether the proof integers used as exponents were even in-bounds. Since `Integer` has no size limit on deserialization, an attacker could craft a proof message with massive integers and pin the verifier with a near-infinite `pow_mod` call — pure DoS, no key material at risk.

The correct pattern is already in the codebase: `paillier_encryption_in_range::interactive::verify` does its range checks upfront before touching any exponentiation. This PR applies the same discipline to the three verifiers that were missing it.

---

### Changes

**`no_small_factor`** (`Π_fac`)

`z1` and `z2` were range-checked at the end of `verify`, after multiple `pow_mod`/`combine` calls that use them. `w1`, `w2`, and `v` had no bounds at all.

- Moved `z1`/`z2` checks before the equality checks
- Added range checks: `w1`, `w2` ∈ ±`2^(l+ε+1) · N̂`, and `v` ∈ ±`n · 2^(l+ε+1) · N̂`

**`paillier_affine_operation_in_range`** (`Π_aff-g`)

Same issue — `z1`/`z2` checked at the end, `z3`/`z4`/`w`/`w_y` unchecked.

- Moved `z1`/`z2` checks before the statement verification block
- Added range checks for `z3`, `z4` (±`N̂ · 2^(l+ε+1)`) and mult-group checks for `w`, `w_y`

**`paillier_encryption_in_range_with_el_gamal`** (`Π_enc-elg`)

`z1` was checked at the very end. `z2` and `z3` had no checks.

- Moved `z1` check before the Paillier operations
- Added mult-group check for `z2` (must be in `Z*_N`) and range check for `z3` (±`N̂ · 2^(l+ε+1)`)

---

### Tests

Each file gets a regression test (`rejects_oversized_response` / `failing_p256_oversized_aux_response`) that injects a crafted `1 << 10_000` integer into the relevant proof field and asserts the verifier rejects it at the correct `RangeCheck` error code before reaching any exponentiation.

All 30 existing tests continue to pass.
