### PR TITLE
Expose set_additive_shift to apply a raw additive key tweak

### DIFF
--- a/cggmp24/src/signing.rs
+++ b/cggmp24/src/signing.rs
@@ -535,6 +535,25 @@ where
         Ok(self)
     }
 
+    /// Specifies a raw additive key shift `IL`, so signing is performed under the
+    /// shifted key `sk + IL` and the resulting signature verifies against the
+    /// shifted public key `pk + IL * G`.
+    ///
+    /// This is the same additive-shift mechanism [`set_derivation_path`] uses, but
+    /// the shift scalar is supplied directly instead of being derived from an HD
+    /// path. It lets a caller that computes the BIP32/SLIP10 child tweak itself
+    /// (e.g. from an externally maintained chain code) apply it without the key
+    /// share carrying an embedded chain code. Passing `IL = 0` is equivalent to no
+    /// shift (signs under the original key). The two methods are mutually
+    /// exclusive — calling both keeps the shift set last.
+    ///
+    /// [`set_derivation_path`]: Self::set_derivation_path
+    #[cfg(feature = "hd-wallet")]
+    pub fn set_additive_shift(mut self, shift: Scalar<E>) -> Self {
+        self.additive_shift = Some(shift);
+        self
+    }
+
     /// Starts presignature generation protocol
     pub async fn generate_presignature<R, M>(
         self,


### PR DESCRIPTION
Adds `SigningBuilder::set_additive_shift(shift: Scalar<E>)`, a public setter for the existing `additive_shift` field that `set_derivation_path` already populates.

## Motivation
Some callers compute the BIP32/SLIP10 non-hardened child tweak `I_L` themselves (e.g. from an externally maintained chain code, when the key share was not generated with an embedded chain code) and need to apply the raw scalar directly. Today the only way to set `additive_shift` is `set_derivation_path`, which re-derives `I_L` internally and requires the share to carry a chain code. This method exposes the same audited shift path for the raw-scalar case.

## What it does
- Feature-gated behind `hd-wallet`, mirroring `set_derivation_path`.
- Sets the same `additive_shift` field; no new crypto. `I_L = 0` is equivalent to no shift.
- The shift is applied unchanged by the existing `signing_t_out_of_n` logic (`X[0] += shift*G`, `x_i += shift` for the first signer), so the signature verifies against `pk + I_L*G`.

Faithful, minimal exposure of an existing code path.