### PR TITLE
perf(paillier-zk): reduce modular exponentiation cost

### DIFF
--- a/cggmp24/src/key_refresh.rs
+++ b/cggmp24/src/key_refresh.rs
@@ -247,6 +247,8 @@ enum Bug {
     GenPedersen(#[source] utils::GenPedersenError),
     #[error("own modulus N is not positive")]
     NegativeModulus,
+    #[error("build CRT for N=p*q")]
+    BuildNCrt,
 }
 
 /// Error indicating that protocol was aborted by malicious party
@@ -270,6 +272,8 @@ enum ProtocolAbortReason {
     InvalidFacProof,
     #[error("N, s and t parameters are invalid")]
     InvalidRingPedersenParameters,
+    #[error("provided invalid proof for Prm")]
+    InvalidPrmProof,
     #[error("round 1 was not reliable")]
     Round1NotReliable,
 }
@@ -292,5 +296,6 @@ impl ProtocolAborted {
         invalid_ring_pedersen_parameters,
         InvalidRingPedersenParameters
     );
+    make_factory!(invalid_prm_proof, InvalidPrmProof);
     make_factory!(round1_not_reliable, Round1NotReliable);
 }

--- a/cggmp24/src/key_refresh/aux_only.rs
+++ b/cggmp24/src/key_refresh/aux_only.rs
@@ -13,8 +13,7 @@ use crate::{
     key_share::{AuxInfo, DirtyAuxInfo, PedersenParams, Validate},
     progress::Tracer,
     security_level::SecurityLevel,
-    utils,
-    utils::{collect_blame, AbortBlame},
+    utils::{self, collect_blame, AbortBlame},
     zk::ring_pedersen_parameters as π_prm,
     ExecutionId,
 };
@@ -187,19 +186,17 @@ where
 
     tracer.stage("Build Paillier key");
     let N = &p * &q;
+    let N_crt = paillier_zk::fast_paillier::utils::CrtExp::build_n(&p, &q).ok_or(Bug::BuildNCrt)?;
 
     tracer.stage("Build Pedersen params");
-    let (pedersen_params, phi_hat_N, lambda) = utils::generate_pedersen_params(rng, hat_p, hat_q)?;
+    let (my_pedersen_params, phi_hat_N, lambda) =
+        utils::generate_pedersen_params(rng, hat_p, hat_q)?;
 
     tracer.stage("Prove Πprm (ψˆ_i)");
     let hat_psi = π_prm::prove::<{ crate::security_level::M }, D>(
         &unambiguous::ProofPrm { sid, prover: i },
         &mut rng,
-        π_prm::Data {
-            N: &pedersen_params.hat_N,
-            s: &pedersen_params.s,
-            t: &pedersen_params.t,
-        },
+        &my_pedersen_params,
         &phi_hat_N,
         &lambda,
     )
@@ -214,9 +211,9 @@ where
     // V_i and u_i in paper
     let decommitment = MsgRound2 {
         N: N.clone(),
-        hat_N: pedersen_params.hat_N.clone(),
-        s: pedersen_params.s.clone(),
-        t: pedersen_params.t.clone(),
+        hat_N: my_pedersen_params.hat_N.clone(),
+        s: my_pedersen_params.s.clone(),
+        t: my_pedersen_params.t.clone(),
         params_proof: hat_psi,
         rho_bytes: rho_bytes.clone(),
         decommit: {
@@ -320,28 +317,58 @@ where
         return Err(ProtocolAborted::invalid_decommitment(blame).into());
     }
     // validate parameters and param_proofs
-    tracer.stage("Validate bit length and П_prm (ψˆ_i)");
-    let blame = collect_blame(&decommitments, &decommitments, |j, d, _| {
+    tracer.stage("Validate pedersen params consistency");
+    let blame = utils::collect_simple_blame(&decommitments, |_, d| {
         if [&d.N, &d.hat_N]
             .iter()
             .any(|biprime| !crate::security_level::validate_public_paillier_key_size::<L>(biprime))
         {
-            true
-        } else {
-            π_prm::verify::<{ crate::security_level::M }, D>(
-                &unambiguous::ProofPrm { sid, prover: j },
-                π_prm::Data {
-                    N: &d.hat_N,
-                    s: &d.s,
-                    t: &d.t,
-                },
-                &d.params_proof,
-            )
-            .is_err()
+            return true;
         }
+        !d.t.in_mult_group_of(&d.hat_N) || !d.s.in_mult_group_of(&d.hat_N)
     });
     if !blame.is_empty() {
         return Err(ProtocolAborted::invalid_ring_pedersen_parameters(blame).into());
+    }
+    tracer.stage("Construct aux info");
+    let mut pedersen_params = decommitments
+        .iter()
+        .map(|d| PedersenParams {
+            hat_N: d.hat_N.clone(),
+            s: d.s.clone(),
+            t: d.t.clone(),
+            multiexp: None,
+            crt: None,
+        })
+        .collect::<Vec<_>>();
+    pedersen_params.insert(i.into(), my_pedersen_params);
+    let mut aux = DirtyAuxInfo {
+        p,
+        q,
+        N: decommitments
+            .iter_including_me(&decommitment)
+            .map(|d| d.N.clone())
+            .collect::<Vec<_>>(),
+        pedersen_params,
+        security_level: std::marker::PhantomData,
+    };
+    if compute_multiexp_table {
+        tracer.stage("Precompute multiexp tables");
+        aux.precompute_multiexp_tables()
+            .map_err(Bug::BuildMultiexpTables)?;
+    }
+
+    tracer.stage("Validate П_prm (ψˆ_i)");
+    let blame = utils::collect_simple_blame(&decommitments, |j, d| {
+        π_prm::verify::<{ crate::security_level::M }, D>(
+            &unambiguous::ProofPrm { sid, prover: j },
+            &aux.pedersen_params[usize::from(j)],
+            &d.params_proof,
+        )
+        .is_err()
+    });
+    if !blame.is_empty() {
+        return Err(ProtocolAborted::invalid_prm_proof(blame).into());
     }
 
     tracer.stage("Add together shared random bytes");
@@ -360,7 +387,11 @@ where
             prover: i,
         },
         π_mod::Data { n: &N },
-        π_mod::PrivateData { p: &p, q: &q },
+        π_mod::PrivateData {
+            p: &aux.p,
+            q: &aux.q,
+            crt: &N_crt,
+        },
         &mut rng,
     )
     .map_err(Bug::PiMod)?;
@@ -372,7 +403,7 @@ where
     let n_sqrt = N.sqrt_ref().ok_or(Bug::NegativeModulus)?;
 
     // message to each party
-    for (j, _, d) in decommitments.iter_indexed() {
+    for j in utils::iter_peers(i, n) {
         tracer.send_msg();
 
         tracer.stage("Compute П_fac (ψ'_i,j)");
@@ -382,18 +413,15 @@ where
                 rho: rho_bytes.as_ref(),
                 prover: i,
             },
-            &π_fac::Aux {
-                s: d.s.clone(),
-                t: d.t.clone(),
-                rsa_modulo: d.hat_N.clone(),
-                multiexp: None,
-                crt: None,
-            },
+            &(&aux.pedersen_params[usize::from(j)]).into(),
             π_fac::Data {
                 n: &N,
                 n_root: &n_sqrt,
             },
-            π_fac::PrivateData { p: &p, q: &q },
+            π_fac::PrivateData {
+                p: &aux.p,
+                q: &aux.q,
+            },
             &π_fac_security,
             &mut rng,
         )
@@ -449,9 +477,9 @@ where
     }
 
     tracer.stage("Validate ψ'_j,i (П_fac)");
-    // verify fac proofs
 
-    let phi_common_aux: π_fac::Aux = (&pedersen_params).into();
+    // verify fac proofs
+    let phi_common_aux: π_fac::Aux = (&aux.pedersen_params[usize::from(i)]).into();
     let blame = collect_blame(
         &decommitments,
         &shares_msg_b,
@@ -483,38 +511,7 @@ where
 
     // verifications passed, compute final key shares
 
-    tracer.stage("Assemble auxiliary info");
-    let mut parties_pedersen = decommitments
-        .iter()
-        .map(|d| PedersenParams {
-            hat_N: d.hat_N.clone(),
-            s: d.s.clone(),
-            t: d.t.clone(),
-            multiexp: None,
-            crt: None,
-        })
-        .collect::<Vec<_>>();
-    parties_pedersen.insert(i.into(), pedersen_params);
-
-    let N = decommitments
-        .into_iter_including_me(decommitment)
-        .map(|d| d.N)
-        .collect::<Vec<_>>();
-    let mut aux = DirtyAuxInfo {
-        p,
-        q,
-        N,
-        pedersen_params: parties_pedersen,
-        security_level: std::marker::PhantomData,
-    };
-
-    if compute_multiexp_table {
-        tracer.stage("Precompute multiexp tables");
-
-        aux.precompute_multiexp_tables()
-            .map_err(Bug::BuildMultiexpTables)?;
-    }
-
+    tracer.stage("Verify consistency of auxiliary info");
     let aux = aux
         .validate()
         .map_err(|err| Bug::InvalidShareGenerated(err.into_error()))?;

--- a/cggmp24/src/signing.rs
+++ b/cggmp24/src/signing.rs
@@ -988,7 +988,7 @@ where
         tracer.msgs_received();
         tracer.stage("Assert other parties hashed messages (reliability check)");
         let parties_have_different_hashes =
-            utils::collect_simple_blame(&round1a_hashes, |hash| hash.0 != h_i);
+            utils::collect_simple_blame(&round1a_hashes, |_j, hash| hash.0 != h_i);
         if !parties_have_different_hashes.is_empty() {
             return Err(SigningAborted::Round1aNotReliable(parties_have_different_hashes).into());
         }

--- a/cggmp24/src/utils.rs
+++ b/cggmp24/src/utils.rs
@@ -126,12 +126,12 @@ where
 /// to the same message.
 pub fn collect_simple_blame<D, F>(messages: &RoundMsgs<D>, mut filter: F) -> Vec<AbortBlame>
 where
-    F: FnMut(&D) -> bool,
+    F: FnMut(u16, &D) -> bool,
 {
     messages
         .iter_indexed()
         .filter_map(|(j, msg_id, data)| {
-            if filter(data) {
+            if filter(j, data) {
                 Some(AbortBlame::new(j, msg_id, msg_id))
             } else {
                 None

--- a/cggmp24/src/zk/ring_pedersen_parameters.rs
+++ b/cggmp24/src/zk/ring_pedersen_parameters.rs
@@ -11,17 +11,6 @@ struct Challenge<const M: usize> {
     es: [bool; M],
 }
 
-/// Data to construct proof about
-#[derive(Clone, Copy, udigest::Digestable)]
-pub struct Data<'a> {
-    #[udigest(as = &crate::utils::encoding::Integer)]
-    pub N: &'a Integer,
-    #[udigest(as = &crate::utils::encoding::Integer)]
-    pub s: &'a Integer,
-    #[udigest(as = &crate::utils::encoding::Integer)]
-    pub t: &'a Integer,
-}
-
 /// The ZK proof. Computed by [`prove`].
 ///
 /// Parameter `M` is security level. The probability of an adversary generating
@@ -40,21 +29,28 @@ pub struct Proof<const M: usize> {
 
 fn derive_challenge<const M: usize, D: Digest>(
     shared_state: &impl udigest::Digestable,
-    data: Data,
+    data: &crate::key_share::PedersenParams,
     commitment: &[Integer; M],
 ) -> Challenge<M> {
     #[derive(udigest::Digestable)]
     #[udigest(tag = "dfns.ring_pedersen_parameters.seed")]
     struct Seed<'a, S: udigest::Digestable, const M: usize> {
         shared_state: &'a S,
-        data: Data<'a>,
+        #[udigest(as = &crate::utils::encoding::Integer)]
+        hat_N: &'a Integer,
+        #[udigest(as = &crate::utils::encoding::Integer)]
+        s: &'a Integer,
+        #[udigest(as = &crate::utils::encoding::Integer)]
+        t: &'a Integer,
         #[udigest(as = &[crate::utils::encoding::Integer; M])]
         commitment: &'a [Integer; M],
     }
 
     let mut rng = rand_hash::HashRng::<D, _>::from_seed(Seed::<_, M> {
         shared_state,
-        data,
+        hat_N: &data.hat_N,
+        s: &data.s,
+        t: &data.t,
         commitment,
     });
 
@@ -76,19 +72,25 @@ fn derive_challenge<const M: usize, D: Digest>(
 /// Compute the proof for the given data, producing random commitment and
 /// deriving deterministic challenge based on `shared_state` and `data`
 ///
+/// Private data:
 /// - `phi` - $φ(N) = (p-1)(q-1)$
 /// - `lambda` - λ such that $s = t^λ$
+/// - `N_crt` is CRT built for fast exponentiation on `data.N`
 pub fn prove<const M: usize, D: Digest>(
     shared_state: &impl udigest::Digestable,
     rng: &mut impl rand_core::RngCore,
-    data: Data,
+    data: &crate::key_share::PedersenParams,
     phi: &Integer,
     lambda: &Integer,
 ) -> Result<Proof<M>, ZkError> {
     let private_commitment = [(); M].map(|()| phi.random_below_ref(rng));
-    let commitment = private_commitment
-        .clone()
-        .map(|a| data.t.pow_mod_ref(&a, data.N));
+    let commitment = private_commitment.clone().map(|a| {
+        if let Some(crt) = &data.crt {
+            crt.exp(&data.t, &crt.prepare_exponent(&a))
+        } else {
+            data.t.pow_mod_ref(&a, &data.hat_N)
+        }
+    });
     // TODO: since array::try_map is not stable yet, we have to be hacky here
     let commitment = if commitment.iter().any(Option::is_none) {
         return Err(Reason::PowMod.into());
@@ -114,18 +116,18 @@ pub fn prove<const M: usize, D: Digest>(
 /// and `data`.
 pub fn verify<const M: usize, D: Digest>(
     shared_state: &impl udigest::Digestable,
-    data: Data,
+    data: &crate::key_share::PedersenParams,
     proof: &Proof<M>,
 ) -> Result<(), InvalidProof> {
     // Verify that inputs are in expected domains
-    if !data.s.in_mult_group_of(data.N) {
+    if !data.s.in_mult_group_of(&data.hat_N) {
         return Err(InvalidProof);
     }
-    if !data.t.in_mult_group_of(data.N) {
+    if !data.t.in_mult_group_of(&data.hat_N) {
         return Err(InvalidProof);
     }
     for (A_i, z_i) in proof.commitment.iter().zip(&proof.zs) {
-        if !A_i.in_mult_group_of(data.N) || z_i.cmp0().is_lt() || z_i >= data.N {
+        if !A_i.in_mult_group_of(&data.hat_N) || z_i.cmp0().is_lt() || *z_i >= data.hat_N {
             return Err(InvalidProof);
         }
     }
@@ -133,9 +135,9 @@ pub fn verify<const M: usize, D: Digest>(
     // Verify statement
     let challenge: Challenge<M> = derive_challenge::<M, D>(shared_state, data, &proof.commitment);
     for ((z, a), e) in proof.zs.iter().zip(&proof.commitment).zip(&challenge.es) {
-        let lhs: Integer = data.t.pow_mod_ref(z, data.N).ok_or(InvalidProof)?;
+        let lhs: Integer = data.t.pow_mod_ref(z, &data.hat_N).ok_or(InvalidProof)?;
         if *e {
-            let rhs = (data.s * a).modulo(data.N);
+            let rhs = (&data.s * a).modulo(&data.hat_N);
             if lhs != rhs {
                 return Err(InvalidProof);
             }
@@ -176,6 +178,7 @@ mod test {
 
         let p = utils::generate_blum_prime(&mut rng, 256);
         let q = utils::generate_blum_prime(&mut rng, 256);
+        let n_crt = paillier_zk::fast_paillier::utils::CrtExp::build_n(&p, &q).unwrap();
         let n = &p * &q;
         let phi = (&p - 1u8) * (&q - 1u8);
 
@@ -184,15 +187,17 @@ mod test {
         let t = r.square().modulo(&n);
         let s = t.pow_mod_ref(&lambda, &n).unwrap();
 
-        let data = super::Data {
-            N: &n,
-            s: &s,
-            t: &t,
+        let data = crate::key_share::PedersenParams {
+            hat_N: n,
+            s,
+            t,
+            multiexp: None,
+            crt: Some(n_crt),
         };
 
         let proof: super::Proof<16> =
-            super::prove::<16, D>(&shared_state, &mut rng, data, &phi, &lambda).unwrap();
-        super::verify::<16, D>(&shared_state, data, &proof).expect("proof should pass");
+            super::prove::<16, D>(&shared_state, &mut rng, &data, &phi, &lambda).unwrap();
+        super::verify::<16, D>(&shared_state, &data, &proof).expect("proof should pass");
     }
 
     #[test]
@@ -202,6 +207,7 @@ mod test {
 
         let p = utils::generate_blum_prime(&mut rng, 256);
         let q = utils::generate_blum_prime(&mut rng, 256);
+        let n_crt = paillier_zk::fast_paillier::utils::CrtExp::build_n(&p, &q).unwrap();
         let n = &p * &q;
         let phi = (&p - 1u8) * (&q - 1u8);
 
@@ -211,15 +217,17 @@ mod test {
         let correct_s = t.pow_mod_ref(&lambda, &n).unwrap();
         let s = (correct_s + 1u8).modulo(&n);
 
-        let data = super::Data {
-            N: &n,
-            s: &s,
-            t: &t,
+        let data = crate::key_share::PedersenParams {
+            hat_N: n,
+            s,
+            t,
+            multiexp: None,
+            crt: Some(n_crt),
         };
 
         let proof: super::Proof<16> =
-            super::prove::<16, D>(&shared_state, &mut rng, data, &phi, &lambda).unwrap();
-        if super::verify::<16, D>(&shared_state, data, &proof).is_ok() {
+            super::prove::<16, D>(&shared_state, &mut rng, &data, &phi, &lambda).unwrap();
+        if super::verify::<16, D>(&shared_state, &data, &proof).is_ok() {
             panic!("proof should fail");
         }
     }

--- a/paillier-zk/src/multiexp.rs
+++ b/paillier-zk/src/multiexp.rs
@@ -37,23 +37,32 @@ impl MultiexpTable {
         }
         let k_x = x_bits / 8 + 1;
         let k_y = y_bits / 8 + 1;
-        let mut s_table = Vec::with_capacity(k_x.try_into().ok()?);
-        let mut t_table = Vec::with_capacity(k_y.try_into().ok()?);
 
         let radix = Integer::from(256u32);
-        let mut s_power = s.pow_mod_ref(&Integer::one(), &N)?;
-        for i in 0..k_x {
-            s_table.push(s_power.clone());
-            if i + 1 < k_x {
-                s_power = s_power.pow_mod_ref(&radix, &N)?;
-            }
-        }
-        let mut t_power = t.pow_mod_ref(&Integer::one(), &N)?;
-        for i in 0..k_y {
-            t_table.push(t_power.clone());
-            if i + 1 < k_y {
-                t_power = t_power.pow_mod_ref(&radix, &N)?;
-            }
+        // s_table[0] = s mod N
+        // s_table[i+1] = s_table[i]^radix mod N
+        let s_table_len = k_x.try_into().ok()?;
+        let s_table = core::iter::successors(Some(s.modulo_ref(&N)), |s_prev| {
+            s_prev.pow_mod_ref(&radix, &N)
+        })
+        .take(s_table_len)
+        .collect::<Vec<_>>();
+
+        // Similarly:
+        // t_table[0] = t mod N
+        // t_table[i+1] = t_table[i]^radix mod N
+        let t_table_len = k_y.try_into().ok()?;
+        let t_table = core::iter::successors(Some(t.modulo_ref(&N)), |t_prev| {
+            t_prev.pow_mod_ref(&radix, &N)
+        })
+        .take(t_table_len)
+        .collect::<Vec<_>>();
+
+        if s_table.len() != s_table_len || t_table.len() != t_table_len {
+            // s_table and t_table are constructed by calling a `pow_mod_ref` which might fail (with
+            // negligible probability). If that happens, table will have less elements than it's
+            // supposed to, we catch it there.
+            return None;
         }
 
         // smallest negative value possible for `x`

--- a/paillier-zk/src/multiexp.rs
+++ b/paillier-zk/src/multiexp.rs
@@ -39,6 +39,8 @@ impl MultiexpTable {
         let k_y = y_bits / 8 + 1;
 
         let radix = Integer::from(256u32);
+        // We construct a table s_table[i] = s^(radix^i) mod N. To optimize the perf, we do that in
+        // a sequence of successive computations:
         // s_table[0] = s mod N
         // s_table[i+1] = s_table[i]^radix mod N
         let s_table_len = k_x.try_into().ok()?;
@@ -48,7 +50,8 @@ impl MultiexpTable {
         .take(s_table_len)
         .collect::<Vec<_>>();
 
-        // Similarly:
+        // We construct a table t_table[i] = t^(radix^i) mod N. To optimize the perf, we do that in
+        // a sequence of successive computations:
         // t_table[0] = t mod N
         // t_table[i+1] = t_table[i]^radix mod N
         let t_table_len = k_y.try_into().ok()?;

--- a/paillier-zk/src/multiexp.rs
+++ b/paillier-zk/src/multiexp.rs
@@ -40,14 +40,20 @@ impl MultiexpTable {
         let mut s_table = Vec::with_capacity(k_x.try_into().ok()?);
         let mut t_table = Vec::with_capacity(k_y.try_into().ok()?);
 
-        let B: u32 = 256;
+        let radix = Integer::from(256u32);
+        let mut s_power = s.pow_mod_ref(&Integer::one(), &N)?;
         for i in 0..k_x {
-            let B_to_i = Integer::u_pow_u(B, i);
-            s_table.push(s.pow_mod_ref(&B_to_i, &N)?);
+            s_table.push(s_power.clone());
+            if i + 1 < k_x {
+                s_power = s_power.pow_mod_ref(&radix, &N)?;
+            }
         }
+        let mut t_power = t.pow_mod_ref(&Integer::one(), &N)?;
         for i in 0..k_y {
-            let B_to_i = Integer::u_pow_u(B, i);
-            t_table.push(t.pow_mod_ref(&B_to_i, &N)?);
+            t_table.push(t_power.clone());
+            if i + 1 < k_y {
+                t_power = t_power.pow_mod_ref(&radix, &N)?;
+            }
         }
 
         // smallest negative value possible for `x`

--- a/paillier-zk/src/no_small_factor.rs
+++ b/paillier-zk/src/no_small_factor.rs
@@ -209,10 +209,7 @@ pub mod interactive {
         let q = aux.combine(pdata.q, &nu)?;
         let a = aux.combine(&alpha, &x)?;
         let b = aux.combine(&beta, &y)?;
-        let t = aux
-            .rsa_modulo
-            .combine(&q, &alpha, &aux.t, &r)
-            .ok_or_else(crate::BadExponent::undefined)?;
+        let t = (aux.pow_mod(&q, &alpha)? * aux.pow_mod(&aux.t, &r)?).modulo(&aux.rsa_modulo);
 
         let commitment = Commitment { p, q, a, b, t };
         let private_commitment = PrivateCommitment {

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -73,6 +73,8 @@ pub struct Data<'a> {
 pub struct PrivateData<'a> {
     pub p: &'a Integer,
     pub q: &'a Integer,
+    /// CRT built for `N=p*q`
+    pub crt: &'a fast_paillier::utils::CrtExp,
 }
 
 /// Prover's first message, obtained by [`interactive::commit`]
@@ -149,22 +151,21 @@ pub mod interactive {
     /// Compute proof for given data and prior protocol values
     pub fn prove<const M: usize>(
         Data { n }: Data,
-        PrivateData { p, q }: PrivateData,
+        PrivateData { p, q, crt }: PrivateData,
         Commitment { ref w }: &Commitment,
         challenge: &Challenge<M>,
     ) -> Result<Proof<M>, Error> {
         let blum_sqrt = |x| blum_sqrt(&x, p, q, n);
         let phi = (p - 1) * (q - 1);
         let n_inverse = n.invert_ref(&phi).ok_or(ErrorReason::Invert)?;
+        let n_inverse = crt.prepare_exponent(&n_inverse);
 
         // We do an extra allocation as workaround while `array::try_map` is not stable
         let points = challenge
             .ys
             .iter()
             .map(|y| {
-                let z = y
-                    .pow_mod_ref(&n_inverse, n)
-                    .ok_or(BadExponent::undefined())?;
+                let z = crt.exp(y, &n_inverse).ok_or(BadExponent::undefined())?;
                 let (a, b, y_) = find_residue(y, w, p, q, n).ok_or(ErrorReason::FindResidue)?;
                 let x = blum_sqrt(blum_sqrt(y_));
                 Ok(ProofPoint { x, a, b, z })
@@ -309,8 +310,13 @@ mod test {
         let p = generate_blum_prime(&mut rng, 256);
         let q = generate_blum_prime(&mut rng, 256);
         let n = &p * &q;
+        let crt = fast_paillier::utils::CrtExp::build_n(&p, &q).unwrap();
         let data = super::Data { n: &n };
-        let pdata = super::PrivateData { p: &p, q: &q };
+        let pdata = super::PrivateData {
+            p: &p,
+            q: &q,
+            crt: &crt,
+        };
         let shared_state = "shared state";
         let proof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();
@@ -332,9 +338,14 @@ mod test {
                 break q;
             }
         };
+        let crt = fast_paillier::utils::CrtExp::build_n(&p, &q).unwrap();
         let n = &p * &q;
         let data = super::Data { n: &n };
-        let pdata = super::PrivateData { p: &p, q: &q };
+        let pdata = super::PrivateData {
+            p: &p,
+            q: &q,
+            crt: &crt,
+        };
         let shared_state = "shared state";
         let proof =
             super::non_interactive::prove::<65, D>(&shared_state, data, pdata, &mut rng).unwrap();

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -16,6 +16,7 @@
 //! let p = Integer::generate_safe_prime(&mut rng, 256);
 //! let q = Integer::generate_safe_prime(&mut rng, 256);
 //! let n = &p * &q;
+//! let crt = paillier_zk::fast_paillier::utils::CrtExp::build_n(&p, &q).ok_or("crt build error")?;
 //!
 //! // 1. P computes a non-interactive proof that `n` is a Paillier-Blum modulus:
 //! use paillier_zk::paillier_blum_modulus as p;
@@ -26,7 +27,7 @@
 //! let shared_state = "some shared state";
 //!
 //! let data = p::Data { n: &n };
-//! let pdata = p::PrivateData { p: &p, q: &q };
+//! let pdata = p::PrivateData { p: &p, q: &q, crt: &crt };
 //!
 //! let proof =
 //!     p::non_interactive::prove::<{SECURITY}, sha2::Sha256>(

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -129,7 +129,6 @@ pub struct NiProof<const M: usize> {
 /// prover gives proof with commitment and challenge.
 pub mod interactive {
     use fast_paillier::backend::Integer;
-    use fast_paillier::utils::CrtExp;
     use rand_core::RngCore;
 
     use crate::common::{
@@ -157,15 +156,15 @@ pub mod interactive {
         let blum_sqrt = |x| blum_sqrt(&x, p, q, n);
         let phi = (p - 1) * (q - 1);
         let n_inverse = n.invert_ref(&phi).ok_or(ErrorReason::Invert)?;
-        let crt = CrtExp::build_n(p, q).ok_or(ErrorReason::Invert)?;
-        let n_inverse = crt.prepare_exponent(&n_inverse);
 
         // We do an extra allocation as workaround while `array::try_map` is not stable
         let points = challenge
             .ys
             .iter()
             .map(|y| {
-                let z = crt.exp(y, &n_inverse).ok_or(BadExponent::undefined())?;
+                let z = y
+                    .pow_mod_ref(&n_inverse, n)
+                    .ok_or(BadExponent::undefined())?;
                 let (a, b, y_) = find_residue(y, w, p, q, n).ok_or(ErrorReason::FindResidue)?;
                 let x = blum_sqrt(blum_sqrt(y_));
                 Ok(ProofPoint { x, a, b, z })

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -129,6 +129,7 @@ pub struct NiProof<const M: usize> {
 /// prover gives proof with commitment and challenge.
 pub mod interactive {
     use fast_paillier::backend::Integer;
+    use fast_paillier::utils::CrtExp;
     use rand_core::RngCore;
 
     use crate::common::{
@@ -156,15 +157,15 @@ pub mod interactive {
         let blum_sqrt = |x| blum_sqrt(&x, p, q, n);
         let phi = (p - 1) * (q - 1);
         let n_inverse = n.invert_ref(&phi).ok_or(ErrorReason::Invert)?;
+        let crt = CrtExp::build_n(p, q).ok_or(ErrorReason::Invert)?;
+        let n_inverse = crt.prepare_exponent(&n_inverse);
 
         // We do an extra allocation as workaround while `array::try_map` is not stable
         let points = challenge
             .ys
             .iter()
             .map(|y| {
-                let z = y
-                    .pow_mod_ref(&n_inverse, n)
-                    .ok_or(BadExponent::undefined())?;
+                let z = crt.exp(y, &n_inverse).ok_or(BadExponent::undefined())?;
                 let (a, b, y_) = find_residue(y, w, p, q, n).ok_or(ErrorReason::FindResidue)?;
                 let x = blum_sqrt(blum_sqrt(y_));
                 Ok(ProofPoint { x, a, b, z })

--- a/tests/src/bin/measure_perf.rs
+++ b/tests/src/bin/measure_perf.rs
@@ -171,6 +171,7 @@ fn do_becnhmarks<L: SecurityLevel>(args: Args) {
                     async move {
                         let aux_data = cggmp24::aux_info_gen(eid, i, n, pregen)
                             .set_progress_tracer(&mut profiler)
+                            .precompute_multiexp_tables(true)
                             .start(&mut party_rng, party)
                             .await
                             .context("aux data gen failed")?;


### PR DESCRIPTION
Closes #233.

Optimize aux info generation:
- Propagate CRT and multiexp optimization to all the proofs
- Improve efficiency of multiexp table construction