### PR TITLE
perf(paillier-zk): retain Montgomery multiexp context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +493,12 @@ checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -586,6 +604,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "serdect",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -713,6 +752,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu-base"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a4867772ef92740ddb786be2aa7407f6588c2f5713cfa3e7ec747dc3a8a221"
+
+[[package]]
+name = "dashu-int"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09237178fe9f89615eb6ba5516fc8c061a4fb203e9550f823f8fbcc4c30e3520"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,8 +837,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.3",
  "digest",
  "ff",
  "generic-array",
@@ -872,10 +930,10 @@ dependencies = [
 [[package]]
 name = "fast-paillier"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f31977dae80ca360f5224c4073b0797851a11f4ea1635bdc86d08a3be87b3a"
+source = "git+https://github.com/noah-dfns/fast-paillier?rev=f88dc22c7956785330440c535f474d9a23b85d39#f88dc22c7956785330440c535f474d9a23b85d39"
 dependencies = [
  "bytemuck",
+ "dashu-int",
  "glass_pumpkin",
  "num-bigint 0.4.6",
  "num-integer",
@@ -1651,6 +1709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1764,7 @@ name = "paillier-zk"
 version = "0.7.0-alpha.4"
 dependencies = [
  "anyhow",
+ "crypto-bigint 0.7.5",
  "digest",
  "fast-paillier",
  "generic-ec",
@@ -2198,6 +2263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,7 +2326,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der",
  "generic-array",
  "subtle",
@@ -2289,22 +2360,32 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -2367,6 +2448,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -2466,7 +2557,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.5.3",
  "hex",
  "hmac",
  "num-bigint 0.4.6",
@@ -2508,7 +2599,7 @@ checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
 dependencies = [
  "ark-ff",
  "bigdecimal",
- "crypto-bigint",
+ "crypto-bigint 0.5.3",
  "getrandom",
  "hex",
  "serde",
@@ -2542,7 +2633,7 @@ checksum = "d9386015d2e6dc3df285bfb33a3afd8ad7596c70ed38ab57019de4d2dfc7826f"
 dependencies = [
  "async-trait",
  "auto_impl",
- "crypto-bigint",
+ "crypto-bigint 0.5.3",
  "eth-keystore",
  "rand",
  "starknet-core",
@@ -2584,6 +2675,17 @@ name = "syn"
 version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cggmp24-keygen = { version = "0.7.0-alpha.4", path = "cggmp24-keygen" }
 key-share = { version = "0.7", path = "key-share", default-features = false }
 paillier-zk = { version = "0.7.0-alpha.4", path = "paillier-zk", default-features = false }
 
-fast-paillier = { version = "0.3.2", default-features = false }
+fast-paillier = { git = "https://github.com/noah-dfns/fast-paillier", rev = "f88dc22c7956785330440c535f474d9a23b85d39", default-features = false }
 generic-ec = { version = "0.5", default-features = false }
 generic-ec-zkp = { version = "0.5", default-features = false }
 round-based = { version = "0.4.1", default-features = false }

--- a/paillier-zk/Cargo.toml
+++ b/paillier-zk/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["paillier", "zk-proofs", "zero-knowledge"]
 generic-ec = { workspace = true, features = ["udigest"] }
 rand_core = { version = "0.6", default-features = false }
 digest = "0.10"
+crypto-bigint = { version = "0.7.5", default-features = false, features = ["alloc"] }
 fast-paillier = { workspace = true }
 
 thiserror = "1"

--- a/paillier-zk/src/multiexp.rs
+++ b/paillier-zk/src/multiexp.rs
@@ -5,6 +5,12 @@
 
 #![allow(non_snake_case)]
 
+use std::sync::OnceLock;
+
+use crypto_bigint::{
+    modular::{BoxedMontyForm, BoxedMontyParams},
+    BoxedUint, Odd,
+};
 use fast_paillier::backend::Integer;
 
 /// Precomputed table for performing faster multiexponentiation
@@ -18,6 +24,17 @@ pub struct MultiexpTable {
     ell_y: Integer,
     t_to_ell_y: Integer,
     N: Integer,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    monty: OnceLock<Option<MontyTable>>,
+}
+
+#[derive(Debug, Clone)]
+struct MontyTable {
+    params: BoxedMontyParams,
+    s: Vec<BoxedMontyForm>,
+    s_to_ell_x: BoxedMontyForm,
+    t: Vec<BoxedMontyForm>,
+    t_to_ell_y: BoxedMontyForm,
 }
 
 impl MultiexpTable {
@@ -63,7 +80,7 @@ impl MultiexpTable {
         let ell_y = -(Integer::one() << (k_y * 8)) + 1;
         let t_to_ell_y = t.pow_mod_ref(&ell_y, &N)?;
 
-        Some(Self {
+        let table = Self {
             s: s_table,
             ell_x,
             s_to_ell_x,
@@ -71,7 +88,10 @@ impl MultiexpTable {
             ell_y,
             t_to_ell_y,
             N,
-        })
+            monty: OnceLock::new(),
+        };
+        let _ = table.monty.set(MontyTable::build(&table));
+        Some(table)
     }
 
     /// Calculates `s^x t^y mod N`
@@ -109,9 +129,22 @@ impl MultiexpTable {
             return None;
         }
 
+        match self.monty.get_or_init(|| MontyTable::build(self)) {
+            Some(table) => Some(table.prod_exp(&x_digits, &y_digits, x_is_neg, y_is_neg)),
+            None => Some(self.prod_exp_standard(&x_digits, &y_digits, x_is_neg, y_is_neg)),
+        }
+    }
+
+    fn prod_exp_standard(
+        &self,
+        x_digits: &[u8],
+        y_digits: &[u8],
+        x_is_neg: bool,
+        y_is_neg: bool,
+    ) -> Integer {
         let mut digits_table = [(); 255].map(|_| None);
-        build_digits_table(&mut digits_table, &self.s, &x_digits, &self.N);
-        build_digits_table(&mut digits_table, &self.t, &y_digits, &self.N);
+        build_integer_digits_table(&mut digits_table, &self.s, x_digits, &self.N);
+        build_integer_digits_table(&mut digits_table, &self.t, y_digits, &self.N);
 
         let mut res = Integer::one();
         let mut acc = Integer::one();
@@ -128,8 +161,7 @@ impl MultiexpTable {
         if y_is_neg {
             res = (res * &self.t_to_ell_y) % &self.N;
         }
-
-        Some(res)
+        res
     }
 
     /// Returns max size of exponents (in bits) that can be computed
@@ -150,6 +182,7 @@ impl MultiexpTable {
             ell_y,
             t_to_ell_y,
             N,
+            monty: _,
         } = self;
 
         // A few bytes to encode length of Vec `s` and `t`
@@ -168,11 +201,18 @@ impl MultiexpTable {
         let limbs_bytes =
             (u32::BITS as usize / 8) * (s + ell_x + s_to_ell_x + t + ell_y + t_to_ell_y + N);
 
-        vec_len + int_len + limbs_bytes
+        let monty = self
+            .monty
+            .get()
+            .and_then(Option::as_ref)
+            .map(MontyTable::size_in_bytes)
+            .unwrap_or(0);
+
+        vec_len + int_len + limbs_bytes + monty
     }
 }
 
-fn build_digits_table(
+fn build_integer_digits_table(
     table: &mut [Option<Integer>; 255],
     base: &[Integer],
     digits: &[u8],
@@ -191,6 +231,84 @@ fn build_digits_table(
     }
 }
 
+impl MontyTable {
+    fn build(table: &MultiexpTable) -> Option<Self> {
+        if table.N.is_even() {
+            return None;
+        }
+
+        let modulus = BoxedUint::from_be_slice_vartime(&table.N.to_bytes_msf());
+        let modulus = Option::<Odd<BoxedUint>>::from(Odd::new(modulus))?;
+        let params = BoxedMontyParams::new_vartime(modulus);
+        let convert = |value: &Integer| {
+            BoxedUint::from_be_slice(&value.to_bytes_msf(), params.bits_precision())
+                .ok()
+                .map(|value| BoxedMontyForm::new(value, &params))
+        };
+
+        Some(Self {
+            s: table.s.iter().map(convert).collect::<Option<_>>()?,
+            s_to_ell_x: convert(&table.s_to_ell_x)?,
+            t: table.t.iter().map(convert).collect::<Option<_>>()?,
+            t_to_ell_y: convert(&table.t_to_ell_y)?,
+            params,
+        })
+    }
+
+    fn prod_exp(
+        &self,
+        x_digits: &[u8],
+        y_digits: &[u8],
+        x_is_neg: bool,
+        y_is_neg: bool,
+    ) -> Integer {
+        let mut digits_table = [(); 255].map(|_| None);
+        build_monty_digits_table(&mut digits_table, &self.s, x_digits);
+        build_monty_digits_table(&mut digits_table, &self.t, y_digits);
+
+        let mut res = BoxedMontyForm::one(&self.params);
+        let mut acc = BoxedMontyForm::one(&self.params);
+        for d in digits_table.iter().rev() {
+            if let Some(d) = d {
+                acc *= d;
+            }
+            res *= &acc;
+        }
+
+        if x_is_neg {
+            res *= &self.s_to_ell_x;
+        }
+        if y_is_neg {
+            res *= &self.t_to_ell_y;
+        }
+
+        Integer::from_bytes_msf(&res.retrieve().to_be_bytes())
+    }
+
+    fn size_in_bytes(&self) -> usize {
+        let values = self.s.len() + self.t.len() + 2;
+        // Include cached residues and the modulus parameters retained by the shared Arc.
+        (values + 4) * usize::try_from(self.params.bits_precision() / 8).unwrap_or(usize::MAX)
+    }
+}
+
+fn build_monty_digits_table(
+    table: &mut [Option<BoxedMontyForm>; 255],
+    base: &[BoxedMontyForm],
+    digits: &[u8],
+) {
+    for (i, digit) in digits.iter().copied().enumerate() {
+        if digit != 0 {
+            match &mut table[usize::from(digit - 1)] {
+                Some(out) => {
+                    *out *= &base[i];
+                }
+                out @ None => *out = Some(base[i].clone()),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use fast_paillier::backend::Integer;
@@ -199,7 +317,37 @@ mod test {
 
     #[test]
     fn multiexp_works() {
-        let N = Integer::from(100000);
+        check_multiexp(Integer::from(100003));
+        check_multiexp(Integer::from(100000));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialized_table_rebuilds_monty_cache() {
+        let table = MultiexpTable::build(
+            &Integer::from(3),
+            &Integer::from(7),
+            48,
+            32,
+            Integer::from(100003),
+        )
+        .unwrap();
+        let encoded = serde_json::to_vec(&table).unwrap();
+        let restored: MultiexpTable = serde_json::from_slice(&encoded).unwrap();
+
+        assert!(restored.monty.get().is_none());
+        assert_eq!(
+            restored
+                .prod_exp(&Integer::from(-12345), &Integer::from(6789))
+                .unwrap(),
+            table
+                .prod_exp(&Integer::from(-12345), &Integer::from(6789))
+                .unwrap()
+        );
+        assert!(restored.monty.get().is_some_and(Option::is_some));
+    }
+
+    fn check_multiexp(N: Integer) {
         let s = Integer::from(3);
         let t = Integer::from(7);
 

--- a/paillier-zk/src/multiexp.rs
+++ b/paillier-zk/src/multiexp.rs
@@ -40,14 +40,20 @@ impl MultiexpTable {
         let mut s_table = Vec::with_capacity(k_x.try_into().ok()?);
         let mut t_table = Vec::with_capacity(k_y.try_into().ok()?);
 
-        let B: u32 = 256;
+        let radix = Integer::from(256u32);
+        let mut s_power = s.pow_mod_ref(&Integer::one(), &N)?;
         for i in 0..k_x {
-            let B_to_i = Integer::u_pow_u(B, i);
-            s_table.push(s.pow_mod_ref(&B_to_i, &N)?);
+            s_table.push(s_power.clone());
+            if i + 1 < k_x {
+                s_power = s_power.pow_mod_ref(&radix, &N)?;
+            }
         }
+        let mut t_power = t.pow_mod_ref(&Integer::one(), &N)?;
         for i in 0..k_y {
-            let B_to_i = Integer::u_pow_u(B, i);
-            t_table.push(t.pow_mod_ref(&B_to_i, &N)?);
+            t_table.push(t_power.clone());
+            if i + 1 < k_y {
+                t_power = t_power.pow_mod_ref(&radix, &N)?;
+            }
         }
 
         // smallest negative value possible for `x`

--- a/paillier-zk/src/paillier_blum_modulus.rs
+++ b/paillier-zk/src/paillier_blum_modulus.rs
@@ -129,6 +129,7 @@ pub struct NiProof<const M: usize> {
 /// prover gives proof with commitment and challenge.
 pub mod interactive {
     use fast_paillier::backend::Integer;
+    use fast_paillier::utils::CrtExp;
     use rand_core::RngCore;
 
     use crate::common::{
@@ -156,15 +157,15 @@ pub mod interactive {
         let blum_sqrt = |x| blum_sqrt(&x, p, q, n);
         let phi = (p - 1) * (q - 1);
         let n_inverse = n.invert_ref(&phi).ok_or(ErrorReason::Invert)?;
+        let crt = CrtExp::build_n(p, q).ok_or(ErrorReason::Invert)?;
+        let n_inverse = crt.prepare_exponent(&n_inverse);
 
         // We do an extra allocation as workaround while `array::try_map` is not stable
         let points = challenge
             .ys
             .iter()
             .map(|y| {
-                let z = y
-                    .pow_mod_ref(&n_inverse, n)
-                    .ok_or(BadExponent::undefined())?;
+                let z = crt.exp(y, &n_inverse).ok_or(BadExponent::undefined())?;
                 let (a, b, y_) = find_residue(y, w, p, q, n).ok_or(ErrorReason::FindResidue)?;
                 let x = blum_sqrt(blum_sqrt(y_));
                 Ok(ProofPoint { x, a, b, z })


### PR DESCRIPTION
## Summary
- cache multiexponentiation table values in a reusable Montgomery domain
- retain the existing implementation as an exact fallback for even moduli
- keep serialized fields unchanged and lazily rebuild the cache after deserialization
- pin the permissively licensed fast-paillier backend from LFDT-Lockness/fast-paillier#42

This is stacked on #234. Review the final commit; after #234 merges, this branch can be rebased to leave only the cache change.

## Performance
The cache alone improved isolated signing tests by about 4%. On top of the Dashu backend, full-suite user CPU fell from 223.17s to a 210.10s median, another 5.9%. The production 512/448-bit table adds approximately 48 KiB of runtime cache.

## Validation
- 28 paillier-zk unit tests
- 6 doctests
- serialization round trip and lazy cache rebuild
- odd-modulus optimized path and even-modulus fallback
- Clippy with warnings denied
- downstream 130-test integration suite, twice

Signed-off-by: Noah <noah@dfns.co>